### PR TITLE
Revert "disable operator" now that the v0.0.0 tag has been pushed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=builder /go/bin/vertical-pod-autoscaler-operator /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/vertical-pod-autoscaler-operator/install /manifests
 CMD ["/usr/bin/vertical-pod-autoscaler-operator"]
-#LABEL io.openshift.release.operator true
+LABEL io.openshift.release.operator true

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -9,4 +9,4 @@ FROM registry.svc.ci.openshift.org/ocp/4.0:base
 COPY --from=builder /go/bin/vertical-pod-autoscaler-operator /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/vertical-pod-autoscaler-operator/install /manifests
 CMD ["/usr/bin/vertical-pod-autoscaler-operator"]
-#LABEL io.openshift.release.operator true
+LABEL io.openshift.release.operator true

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,10 @@ generate: ## Code generation (requires operator-sdk >= v0.5.0)
 
 .PHONY: build
 build: ## build binaries
+	@# version must be of the form v1.2.3 with optional suffixes -4 and/or -g56789ab
+	@# or the binary will crash when it tries to parse its version.Raw
+	@echo $(VERSION) | grep -qP '^v\d+\.\d+\.\d+(-\d+)?(-g[a-f0-9]{7,})?(-dirty)?$$' || \
+		{ echo "Invalid version $(VERSION), cannot build"; false; }
 	$(DOCKER_CMD) go build $(GOGCFLAGS) -ldflags "$(LD_FLAGS)" -o "$(BUILD_DEST)" "$(REPO_PATH)/cmd/manager"
 
 .PHONY: images

--- a/install/02_vpa-rbac.yaml
+++ b/install/02_vpa-rbac.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -151,7 +152,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: system:controllers-reader
+  name: system:vpa-target-reader
 rules:
 - apiGroups:
   - ""
@@ -164,8 +165,18 @@ rules:
 - apiGroups:
   - apps
   resources:
-  - statefulsets
+  - daemonsets
+  - deployments
   - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
   verbs:
   - get
   - list
@@ -174,12 +185,18 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: system:vpa-updater-controllers-reader-binding
+  name: system:vpa-target-reader-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:controllers-reader
+  name: system:vpa-target-reader
 subjects:
+- kind: ServiceAccount
+  name: vpa-recommender
+  namespace: openshift-vertical-pod-autoscaler
+- kind: ServiceAccount
+  name: vpa-admission-controller
+  namespace: openshift-vertical-pod-autoscaler
 - kind: ServiceAccount
   name: vpa-updater
   namespace: openshift-vertical-pod-autoscaler
@@ -230,6 +247,15 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - "admissionregistration.k8s.io"
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
 - apiGroups:
   - "poc.autoscaling.k8s.io"
   resources:

--- a/install/05_vpa-crd.yaml
+++ b/install/05_vpa-crd.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: verticalpodautoscalers.autoscaling.k8s.io
+spec:
+  group: autoscaling.k8s.io
+  scope: Namespaced
+  names:
+    plural: verticalpodautoscalers
+    singular: verticalpodautoscaler
+    kind: VerticalPodAutoscaler
+    shortNames:
+    - vpa
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1beta2
+    served: true
+    storage: true
+  validation:
+    # openAPIV3Schema is the schema for validating custom objects.
+    openAPIV3Schema:
+      properties:
+        spec:
+          required: []
+          properties:
+            targetRef:
+              type: object
+            updatePolicy:
+              properties:
+                updateMode:
+                  type: string
+            resourcePolicy:
+              properties:
+                containerPolicies:
+                  type: array
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: verticalpodautoscalercheckpoints.autoscaling.k8s.io
+spec:
+  group: autoscaling.k8s.io
+  scope: Namespaced
+  names:
+    plural: verticalpodautoscalercheckpoints
+    singular: verticalpodautoscalercheckpoint
+    kind: VerticalPodAutoscalerCheckpoint
+    shortNames:
+    - vpacheckpoint
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1beta2
+    served: true
+    storage: true
+

--- a/pkg/controller/verticalpodautoscaler/verticalpodautoscaler_controller.go
+++ b/pkg/controller/verticalpodautoscaler/verticalpodautoscaler_controller.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -347,6 +348,12 @@ func (r *Reconciler) RecommenderPodSpec(vpa *autoscalingv1.VerticalPodAutoscaler
 				Image:   r.config.Image,
 				Command: []string{"recommender"},
 				Args:    args,
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceName(corev1.ResourceCPU):    resource.MustParse("25m"),
+						corev1.ResourceName(corev1.ResourceMemory): resource.MustParse("25Mi"),
+					},
+				},
 			},
 		},
 		Tolerations: []corev1.Toleration{

--- a/pkg/operator/status_test.go
+++ b/pkg/operator/status_test.go
@@ -137,7 +137,7 @@ var (
 			APIVersion: "apps/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("vertical-pod-autoscaler-%s", VerticalPodAutoscalerName),
+			Name:      fmt.Sprintf("vpa-recommender-%s", VerticalPodAutoscalerName),
 			Namespace: VerticalPodAutoscalerNamespace,
 			Annotations: map[string]string{
 				util.ReleaseVersionAnnotation: ReleaseVersion,
@@ -151,7 +151,7 @@ var (
 	})
 )
 
-func TestCheckCheckVerticalPodAutoscaler(t *testing.T) {
+func TestCheckCheckVPARecommender(t *testing.T) {
 	testCases := []struct {
 		label        string
 		expectedBool bool
@@ -209,7 +209,7 @@ func TestCheckCheckVerticalPodAutoscaler(t *testing.T) {
 				config:       &TestStatusReporterConfig,
 			}
 
-			ok, err := reporter.CheckVerticalPodAutoscaler()
+			ok, err := reporter.CheckVPARecommender()
 
 			if ok != tc.expectedBool {
 				t.Errorf("got %t, want %t", ok, tc.expectedBool)


### PR DESCRIPTION
This reverts commit 94f9117170b3ad279a3cc72395466f8fcb2bdf64 from #3.
Also:
* check the version string at build time to make sure its format can be parsed
* add resource request to make pod burstable instead of best effort.
* fix the status check to look for the correct deployment name