### PR TITLE
re-disable operator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=builder /go/bin/vertical-pod-autoscaler-operator /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/vertical-pod-autoscaler-operator/install /manifests
 CMD ["/usr/bin/vertical-pod-autoscaler-operator"]
-LABEL io.openshift.release.operator true
+#LABEL io.openshift.release.operator true

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -9,4 +9,4 @@ FROM registry.svc.ci.openshift.org/ocp/4.0:base
 COPY --from=builder /go/bin/vertical-pod-autoscaler-operator /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/vertical-pod-autoscaler-operator/install /manifests
 CMD ["/usr/bin/vertical-pod-autoscaler-operator"]
-LABEL io.openshift.release.operator true
+#LABEL io.openshift.release.operator true


### PR DESCRIPTION
Due to some gaps we uncovered with how to rollout Tech Preview operator with the CVO, we are disabling this in 4.2.  Looking to enable again in 4.3 after coordinating with CVO on design for Tech Preview operators.

@derekwaynecarr @smarterclayton @joelsmith @tkatarki @blomquisg 