### PR TITLE
Fix inconsistency between RBAC and CSV required permissions

### DIFF
--- a/install/02_vpa-rbac.yaml
+++ b/install/02_vpa-rbac.yaml
@@ -22,6 +22,7 @@ rules:
   resources:
   - pods
   - nodes
+  - limitranges
   verbs:
   - get
   - list
@@ -177,6 +178,7 @@ rules:
   - batch
   resources:
   - jobs
+  - cronjobs
   verbs:
   - get
   - list
@@ -204,7 +206,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: system:vpa-evictionter-binding
+  name: system:vpa-evictioner-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -243,6 +245,7 @@ rules:
   - pods
   - configmaps
   - nodes
+  - limitranges
   verbs:
   - get
   - list


### PR DESCRIPTION
... and also fix a typo in CRB name

I wasn't sure whether the required permissions in the CSV were correct, or the RBAC in the RBAC file were correct, but the RBAC was not providing sufficient permissions and OLM was rejecting installation of the operator.  If the required permissions are what is not correct I can fix those instead.