### PR TITLE
bug 1803231: image-references: align names with RCM standards

### DIFF
--- a/manifests/4.5/image-references
+++ b/manifests/4.5/image-references
@@ -3,11 +3,11 @@ kind: ImageStream
 apiVersion: image.openshift.io/v1
 spec:
   tags:
-  - name: vertical-pod-autoscaler-operator
+  - name: vertical-pod-autoscaler-rhel7-operator
     from:
       kind: DockerImage
       name: quay.io/openshift/vertical-pod-autoscaler-operator:4.5
-  - name: vertical-pod-autoscaler
+  - name: vertical-pod-autoscaler-rhel7
     from:
       kind: DockerImage
       name: quay.io/openshift/vertical-pod-autoscaler:4.5


### PR DESCRIPTION
I'm pretty sure we're gonna need this; I keep finding out ways this doesn't work how I expect.

I'm testing out builds to make sure. If so, we can probably re-use bug 1803231 since it's the same problem.