### PR TITLE
Add required CSV fields, update VPA CR example, add VPA Controller CR example

### DIFF
--- a/manifests/4.5/vertical-pod-autoscaler.v4.5.0.clusterserviceversion.yaml
+++ b/manifests/4.5/vertical-pod-autoscaler.v4.5.0.clusterserviceversion.yaml
@@ -7,12 +7,51 @@ metadata:
     alm-examples: |
       [
         {
-          "apiVersion": "vertical-pod-autoscaler.operator.k8s.io/v1alpha1",
-          "kind": "VerticalPodAutoscaler",
+          "apiVersion": "autoscaling.openshift.io/v1",
+          "kind": "VerticalPodAutoscalerController",
           "metadata": {
-            "name": "vertical-pod-autoscaler",
+            "name": "default",
             "namespace": "openshift-vertical-pod-autoscaler"
+          },
+          "spec": {
+            "podMinCPUMillicores": 25,
+            "podMinMemoryMb": 250,
+            "recommendationOnly": false,
+            "safetyMarginFraction": 0.15
           }
+        },
+        {
+           "apiVersion": "autoscaling.k8s.io/v1beta2",
+           "kind": "VerticalPodAutoscaler",
+           "metadata": {
+              "name": "myapp-vpa"
+           },
+           "spec": {
+              "targetRef": {
+                 "apiVersion": "apps/v1",
+                 "kind": "Deployment",
+                 "name": "myapp-deployment"
+              },
+              "resourcePolicy": {
+                 "containerPolicies": [
+                    {
+                       "containerName": "*",
+                       "minAllowed": {
+                          "cpu": "100m",
+                          "memory": "50Mi"
+                       },
+                       "maxAllowed": {
+                          "cpu": 1,
+                          "memory": "500Mi"
+                       },
+                       "controlledResources": [
+                          "cpu",
+                          "memory"
+                       ]
+                    }
+                 ]
+              }
+           }
         }
       ]
     capabilities: Full Lifecycle
@@ -26,6 +65,10 @@ metadata:
     support: Red Hat
     operatorframework.io/suggested-namespace: openshift-vertical-pod-autoscaler
 spec:
+  description: An operator to run the OpenShift Vertical Pod Autoscaler. Vertical Pod Autoscaler (VPA) can be configured to monitor a workload's resource utilization, and then adjust its CPU and memory limits by updating the pod (future) or restarting the pod with updated limits.
+  links:
+  - url: https://docs.openshift.com/container-platform/latest/nodes/pods/nodes-pods-vertical-autoscaler.html
+    name: Vertical Pod Autoscaler Documentation
   install:
     strategy: deployment
     spec:
@@ -438,6 +481,9 @@ spec:
   version: 1.0.0
   maturity: alpha
   minKubeVersion: 1.11.0
+  maintainers:
+  - email: support@redhat.com
+    name: Red Hat
   provider:
     name: Red Hat
   displayName: VerticalPodAutoscaler


### PR DESCRIPTION
The last image build failed the metadation validation step. See http://external-ci-coldstorage.datahub.redhat.com/cvp/cvp-redhat-operator-metadata-validation-test/ose-vertical-pod-autoscaler-operator-metadata-container-v4.5.0.202006031723.dev-1/ca074d41-4ded-4a5f-912a-1bfaaf6188c7/operator-metadata-linting-output.txt

This PR adds the required and recommended fields.

To validate the manifests, I did:
```
$ pip3 install operator-courier
$ operator-courier verify --ui_validate_io manifests/
```
which is what the metadata import process does as part of its tests.