### PR TITLE
Bug 1844760: Additional instructions for testing the VPA until official images are available

### DIFF
--- a/manifests/4.5/vertical-pod-autoscaler.v4.5.0.clusterserviceversion.yaml
+++ b/manifests/4.5/vertical-pod-autoscaler.v4.5.0.clusterserviceversion.yaml
@@ -188,6 +188,15 @@ spec:
           - get
           - list
           - watch
+        # from ClusterRole system:vpa-status-reader
+        - apiGroups:
+            - "coordination.k8s.io"
+          resources:
+            - leases
+          verbs:
+            - get
+            - list
+            - watch
       - serviceAccountName: vpa-recommender
         rules:
         #from ClusterRole system:metrics-reader
@@ -344,6 +353,17 @@ spec:
           - get
           - list
           - watch
+        # from ClusterRole system:admission-controller
+        - apiGroups:
+          - "coordination.k8s.io"
+          resources:
+            - leases
+          verbs:
+            - create
+            - update
+            - get
+            - list
+            - watch
         # from ClusterRole system:vpa-target-reader
         - apiGroups:
           - ""


### PR DESCRIPTION
VPA operand rebased from upstream and picked up these changes, which cause
the updater and admission controller to fail without the updated RBAC.

https://github.com/kubernetes/autoscaler/commit/91b955316e6731f81ce8fc0c11c86db6a6300e2f#diff-d0e893b6e6e2716c431b53ecf48088b5R267
https://github.com/kubernetes/autoscaler/commit/572331a244eb30fad83e8bed7882b4756ba9d21c#diff-d0e893b6e6e2716c431b53ecf48088b5R290