### PR TITLE
bug 1882524: [release-4.6] manifests/art.yaml: CSV name is verticalpodautoscaler

### DIFF
--- a/manifests/art.yaml
+++ b/manifests/art.yaml
@@ -2,13 +2,13 @@ updates:
   - file: "{MAJOR}.{MINOR}/vertical-pod-autoscaler.v{MAJOR}.{MINOR}.0.clusterserviceversion.yaml" # relative to this file
     update_list:
       # replace metadata.name value
-      - search: "vertical-pod-autoscaler-operator.v{MAJOR}.{MINOR}.0"
-        replace: "vertical-pod-autoscaler-operator.{FULL_VER}"
+      - search: "verticalpodautoscaler.v{MAJOR}.{MINOR}.0"
+        replace: "verticalpodautoscaler.{FULL_VER}"
       - search: "version: {MAJOR}.{MINOR}.0"
         replace: "version: {FULL_VER}"
       - search: 'olm.skipRange: ">=4.5.0 <{MAJOR}.{MINOR}.0"'
         replace: 'olm.skipRange: ">=4.5.0 <{FULL_VER}"'
   - file: "vertical-pod-autoscaler.package.yaml"
     update_list:
-      - search: "currentCSV: vertical-pod-autoscaler-operator.v4.6.0"
-        replace: "currentCSV: vertical-pod-autoscaler-operator.{FULL_VER}"
+      - search: "currentCSV: verticalpodautoscaler.v4.6.0"
+        replace: "currentCSV: verticalpodautoscaler.{FULL_VER}"


### PR DESCRIPTION
Having successfully pushed to stage once, tests began failing, revealing that the CSV name replacement that was supposed to happen to give it a unique name for each build - wasn't matching. So it gets the same name every time which fails the test. This should make the match work. This is required to ship.