### PR TITLE
Add bugzilla component to OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,3 +2,6 @@ approvers:
   - joelsmith
   - sjenning
   - rphillips
+
+# Bugzilla fields:
+component: Node


### PR DESCRIPTION
This PR should get rid of the nag email from ART. From the email:

> To comply with prodsec requirements, all images in the OpenShift product should identify their Bugzilla component. To accomplish this, ART expects to find Bugzilla component information in the default branch of the image's upstream repository or requires it in ART image metadata.
