### PR TITLE
Match version with ART subst rule

### DIFF
--- a/manifests/4.6/vertical-pod-autoscaler.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/4.6/vertical-pod-autoscaler.v4.6.0.clusterserviceversion.yaml
@@ -499,7 +499,7 @@ spec:
     type: MultiNamespace
   - supported: false
     type: AllNamespaces
-  version: 1.0.0
+  version: 4.6.0
   maturity: alpha
   minKubeVersion: 1.11.0
   maintainers:


### PR DESCRIPTION
https://github.com/jupierce/vertical-pod-autoscaler-operator/blob/a62cd2f36bf045265ce5805299edd11d5a43f085/manifests/art.yaml#L7-L8 expects to find 4.6.0 to replace the version in the CSV. 