### PR TITLE
bug 1904260: CSV: make version match what art.yaml looks for

### DIFF
--- a/manifests/4.6/vertical-pod-autoscaler.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/4.6/vertical-pod-autoscaler.v4.6.0.clusterserviceversion.yaml
@@ -499,7 +499,7 @@ spec:
     type: MultiNamespace
   - supported: false
     type: AllNamespaces
-  version: 1.0.0
+  version: 4.6.0
   maturity: alpha
   minKubeVersion: 1.11.0
   maintainers:


### PR DESCRIPTION
This version needs to change each time it's released;
without this it will stay `1.0.0` forever and fail tests.

We will need the same thing for 4.7+ (though it needs to be `4.7.0` there).