### PR TITLE
remove image-ci target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ export CSV_FILE_PATH_IN_REGISTRY_IMAGE 	= /manifests/$(REGISTRY_VERSION)/vertica
 
 # build image for ci
 CI_REPO ?=registry.svc.ci.openshift.org
+$(call build-image,vertical-pod-autoscaler-operator,$(CI_IMAGE_REGISTRY)/autoscaling/vertical-pod-autoscaler-operator,./images/ci/Dockerfile,.)
 
 # Added LOCAL_OPERATOR_IMAGE for local-image build
 DEV_REPO			?= quay.io/redhat
@@ -112,9 +113,6 @@ dev-image:
 dev-push:
 	$(DOCKER_RUNTIME) push "$(DEV_REPO)/$(DEV_OPERATOR_IMAGE):$(MUTABLE_TAG)"
 
-ci-image:
-	$(IMAGE_BUILD_CMD) -t $(CI_IMAGE_REGISTRY)/autoscaling/vertical-pod-autoscaler-operator -f ./images/ci/Dockerfile .
-
 .PHONY: images
 images: ## Create images
 	$(IMAGE_BUILD_CMD) -t "$(IMAGE):$(VERSION)" -t "$(IMAGE):$(MUTABLE_TAG)" ./
@@ -171,11 +169,11 @@ e2e-local: dev-image dev-push deploy test-e2e
 
 e2e-olm-ci: DEPLOY_MODE := ci
 e2e-olm-ci: KUBECTL=$(shell which oc)
-e2e-olm-ci: ci-image deploy-olm-ci test-e2e
+e2e-olm-ci: deploy-olm-ci test-e2e
 
 e2e-ci: DEPLOY_MODE := ci
 e2e-ci: KUBECTL=$(shell which oc)
-e2e-ci: ci-image deploy test-e2e
+e2e-ci: deploy test-e2e
 
 deploy-olm-local: operator-registry-deploy-local olm-generate olm-apply
 deploy-olm-ci: operator-registry-deploy-ci olm-generate olm-apply

--- a/images/operator-registry/Dockerfile.registry.ci
+++ b/images/operator-registry/Dockerfile.registry.ci
@@ -1,0 +1,35 @@
+FROM quay.io/operator-framework/upstream-registry-builder:v1.13.9 as registry-builder
+
+# Since we will use an init container to mutate the CSV file, there is no point in
+# generating the sqlite db here.
+# Rather, we will run the 'initializer' binary in the init container.
+# We only need the binaries from this image.
+
+
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.15 AS operator-builder
+
+WORKDIR /
+COPY hack/ /scripts
+COPY manifests/ /manifests
+
+# build operator registry image
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.15
+
+ARG VERSION
+
+# copy required binaries and scripts
+COPY --from=registry-builder /bin/initializer /usr/bin/initializer
+COPY --from=registry-builder /bin/registry-server /usr/bin/registry-server
+COPY --from=registry-builder /bin/grpc_health_probe /usr/bin/grpc_health_probe
+COPY --from=operator-builder /scripts/registry-init.sh /scripts/registry-init.sh
+
+# copy the manifests
+COPY --from=operator-builder /manifests /manifests
+RUN chmod ugo+rwx -R /manifests
+
+WORKDIR /bundle
+
+ENV CSV_FILE_PATH=/manifests/${VERSION}/vertical-pod-autoscaler.v${VERSION}.0.clusterserviceversion.yaml
+ENV VERSION=${VERSION}
+
+EXPOSE 50051


### PR DESCRIPTION
Remove makefile image-ci target to use the default image-build macro.
Add dockerfile.ci for registry image.