### PR TITLE
Better handling of NO_DOCKER=1 in check scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ ifeq ($(NO_DOCKER), 1)
 else
   DOCKER_CMD := $(DOCKER_RUNTIME) run --rm -v "$(CURDIR):/go/src/$(REPO_PATH):Z" -w "/go/src/$(REPO_PATH)" openshift/origin-release:golang-1.15
 endif
+export NO_DOCKER
 
 .PHONY: depend
 depend:
@@ -153,10 +154,12 @@ vet: ## Apply go vet to all go files
 help:
 	@grep -E '^[a-zA-Z/0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-clean:
-	rm -rf $(OUTPUT_DIR)
-	
-clean-deploy:
+.PHONY: clean
+clean:  ## Remove build artifacts
+	rm -rf $(OUTPUT_DIR) bin
+
+.PHONY: clean-deploy
+clean-deploy: ## Uninstall VPA from current cluster
 	$(KUBECTL) delete mutatingwebhookconfigurations vpa-webhook-config || true
 	$(KUBECTL) delete ns openshift-vertical-pod-autoscaler || true
 	$(KUBECTL) delete crd verticalpodautoscalercheckpoints.autoscaling.k8s.io verticalpodautoscalercontrollers.autoscaling.openshift.io verticalpodautoscalers.autoscaling.k8s.io || true

--- a/hack/go-fmt.sh
+++ b/hack/go-fmt.sh
@@ -8,7 +8,7 @@ else
   DOCKER_RUNTIME=docker
 fi
 
-if [ "$IS_CONTAINER" != "" ]; then
+if [ "$NO_DOCKER" = "1" -o "$IS_CONTAINER" != "" ]; then
   for TARGET in "${@}"; do
     find "${TARGET}" -name '*.go' ! -path '*/vendor/*' ! -path '*/.build/*' -exec gofmt -s -w {} \+
   done

--- a/hack/go-lint.sh
+++ b/hack/go-lint.sh
@@ -2,7 +2,7 @@
 # Example:  ./hack/go-lint.sh installer/... pkg/... tests/smoke
 
 REPO_NAME=$(basename "${PWD}")
-if [ "$IS_CONTAINER" != "" ]; then
+if [ "$NO_DOCKER" = "1" -o "$IS_CONTAINER" != "" ]; then
   golint -set_exit_status "${@}"
 else
   podman run --rm \

--- a/hack/go-vet.sh
+++ b/hack/go-vet.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 REPO_NAME=$(basename "${PWD}")
-if [ "$IS_CONTAINER" != "" ]; then
+if [ "$NO_DOCKER" = "1" -o "$IS_CONTAINER" != "" ]; then
   go vet "${@}"
 else
   podman run --rm \

--- a/hack/yaml-lint.sh
+++ b/hack/yaml-lint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-if [ "$IS_CONTAINER" != "" ]; then
+if [ "$NO_DOCKER" = "1" -o "$IS_CONTAINER" != "" ]; then
   yamllint --config-data "{extends: default, rules: {line-length: {level: warning, max: 120}}}" ./examples/
 else
   podman run --rm \


### PR DESCRIPTION
If `NO_DOCKER=1` is set, check scripts should not try to run in a container.

Also, add `make help` text for `make clean` and `make clean-deploy`