### PR TITLE
Separate build from registry-update binary build

### DIFF
--- a/hack/deploy-operator-registry.sh
+++ b/hack/deploy-operator-registry.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+NAMESPACE=$1
+if [ "${NAMESPACE}" == "" ]; then
+  echo "Must specify a namespace" >&2
+  exit 1
+fi
+
+KUBECTL=$2
+if [ "${KUBECTL}" == "" ]; then
+  echo "Must specify a path to kubectl/oc binary" >&2
+  exit 1
+fi
+
+MANIFESTS=$3
+if [ "${MANIFESTS}" == "" ]; then
+  echo "Must specify a path to the kube manifests" >&2
+  exit 1
+fi
+
+echo "setting up namespace" >&2
+NAME=$(${KUBECTL} get namespace ${NAMESPACE} -o jsonpath='{.metadata.name}' 2>/dev/null || echo "does not exist")
+if [ "${NAME}" != "${NAMESPACE}" ]; then
+  ${KUBECTL} create ns ${NAMESPACE}
+fi
+
+echo "applying configmap" >&2
+CONFIGMAP_FILE="${MANIFESTS}/registry-env.yaml"
+${KUBECTL} apply -n ${NAMESPACE} -f ${CONFIGMAP_FILE}
+
+echo "creating deployment" >&2
+OPERATOR_REGISTRY_DEPLOYMENT_FILE="${MANIFESTS}/registry-deployment.yaml"
+
+OPERATOR_REGISTRY_DEPLOYMENT_NAME=$(yq -e '.metadata.name' ${OPERATOR_REGISTRY_DEPLOYMENT_FILE} || echo "null")
+OPERATOR_REGISTRY_DEPLOYMENT_NAME=$(echo "$OPERATOR_REGISTRY_DEPLOYMENT_NAME" | sed -r 's/^"|"$//g')
+if [ "${OPERATOR_REGISTRY_DEPLOYMENT_NAME}" == "null" ] || [ "${OPERATOR_REGISTRY_DEPLOYMENT_NAME}" == "" ]; then
+  echo "could not retrieve Deployment name from ${OPERATOR_REGISTRY_DEPLOYMENT_FILE}" >&2
+  exit 1
+fi
+
+${KUBECTL} apply -n ${NAMESPACE} -f ${OPERATOR_REGISTRY_DEPLOYMENT_FILE}
+
+echo "waiting for deployment to be available ${NAMESPACE}/${OPERATOR_REGISTRY_DEPLOYMENT_NAME}" >&2
+${KUBECTL} -n ${NAMESPACE} rollout status -w deployment/${OPERATOR_REGISTRY_DEPLOYMENT_NAME}
+
+echo "creating service" >&2
+SERVICE_FILE="${MANIFESTS}/service.yaml"
+SERVICE_NAME=$(yq -e '.metadata.name' ${SERVICE_FILE} || echo "null")
+SERVICE_NAME=$(echo "$SERVICE_NAME" | sed -r 's/^"|"$//g')
+if [ "${SERVICE_NAME}" == "null" ] || [ "${SERVICE_NAME}" == "" ]; then
+  echo "could not retrieve Service name from ${SERVICE_FILE}" >&2
+  exit 1
+fi
+
+${KUBECTL} apply -n ${NAMESPACE} -f ${MANIFESTS}/service.yaml
+
+CLUSTER_IP=$(${KUBECTL} -n ${NAMESPACE} get service ${SERVICE_NAME} -o jsonpath='{.spec.clusterIP}' || echo "")
+if [ "${CLUSTER_IP}" == "" ]; then
+  echo "could not retrieve clusterIP from Service ${SERVICE_NAME}" >&2
+  exit 1
+fi
+
+echo "clusterIP=${CLUSTER_IP} from Service=${SERVICE_NAME}" >&2
+
+CATALOG_SOURCE_FILE="${MANIFESTS}/catalog-source.yaml"
+sed "s/CLUSTER_IP/${CLUSTER_IP}/g" -i "${CATALOG_SOURCE_FILE}"
+${KUBECTL} apply -n ${NAMESPACE} -f ${CATALOG_SOURCE_FILE}
+
+

--- a/images/operator-registry/Dockerfile.registry.ci
+++ b/images/operator-registry/Dockerfile.registry.ci
@@ -26,6 +26,8 @@ COPY --from=operator-builder /scripts/registry-init.sh /scripts/registry-init.sh
 # copy the manifests
 COPY --from=operator-builder /manifests /manifests
 RUN chmod ugo+rwx -R /manifests
+RUN rm /manifests/art.yaml
+RUN rm /manifests/*/image-references
 
 WORKDIR /bundle
 

--- a/install/olm/registry/catalog-source.yaml
+++ b/install/olm/registry/catalog-source.yaml
@@ -1,9 +1,7 @@
----
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
-  name: vpa-operator-catalog
-  namespace: OPERATOR_NAMESPACE_PLACEHOLDER
+  name: vpa-catalog
 spec:
   sourceType: grpc
-  image: VPA_OPERATOR_REGISTRY_IMAGE
+  address: CLUSTER_IP:50051

--- a/install/olm/registry/registry-deployment.yaml
+++ b/install/olm/registry/registry-deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vpa-operator-registry
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      registry.operator.verticalpodautoscaler: "true"
+  template:
+    metadata:
+      labels:
+        registry.operator.verticalpodautoscaler: "true"
+      name: vpa-operator-registry
+    spec:
+      initContainers:
+      - name: mutate-csv-and-generate-sqlite-db
+        image: VPA_OPERATOR_REGISTRY_IMAGE
+        imagePullPolicy: Always
+        command:
+        - sh
+        args:
+        - /scripts/registry-init.sh
+        envFrom:
+        - configMapRef:
+            name: vpa-operator-registry-env
+        volumeMounts:
+        - name: workdir
+          mountPath: /bundle
+      containers:
+      - name: vpa-operator-registry
+        image: VPA_OPERATOR_REGISTRY_IMAGE
+        imagePullPolicy: Always
+        command:
+        - /usr/bin/registry-server
+        - --database=/bundle/bundles.db
+        volumeMounts:
+        - name: workdir
+          mountPath: /bundle
+        ports:
+        - containerPort: 50051
+          name: grpc
+          protocol: TCP
+        livenessProbe:
+          exec:
+            command:
+            - grpc_health_probe
+            - -addr=localhost:50051
+        readinessProbe:
+          exec:
+            command:
+            - grpc_health_probe
+            - -addr=localhost:50051
+        resources:
+          requests:
+            cpu: 10m
+            memory: 100Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      volumes:
+      - name: workdir
+        emptyDir: {}

--- a/install/olm/registry/service.yaml
+++ b/install/olm/registry/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: vpa-operator-registry
+spec:
+  type: ClusterIP
+  selector:
+    registry.operator.verticalpodautoscaler: "true"
+  ports:
+  - name: grpc
+    port: 50051
+    protocol: TCP
+    targetPort: 50051
+  sessionAffinity: None
+

--- a/install/olm/subscription/subscription.yaml
+++ b/install/olm/subscription/subscription.yaml
@@ -8,5 +8,5 @@ spec:
   channel: OPERATOR_PACKAGE_CHANNEL
   installPlanApproval: Automatic
   name: vertical-pod-autoscaler
-  source: vpa-operator-catalog
+  source: vpa-catalog
   sourceNamespace: OPERATOR_NAMESPACE_PLACEHOLDER


### PR DESCRIPTION
1. Separate registry-update-binary target from build.
2. Use deployment+service+catalogsource (GRPC) way to deploy vpa-registry image in CI mode as the CI image building process cannot replace the operator and operand image on the fly.
3. Update  images/operator-registry/Dockerfile.registry.ci that will be used in the CI mode.