### PR TITLE
Update e2e.sh

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -56,7 +56,7 @@ function await_for_controllers() {
       return
     fi
     retries=$((retries - 1))
-    sleep 3
+    sleep 5
   done
   echo "unknown"
   return
@@ -75,7 +75,7 @@ cd ${GOPATH}/src/k8s.io && git clone -b ${RELEASE_VERSION} --single-branch https
 echo "Check the VerticalPodAutoScalerController configurations ..."
 SCRIPT_ROOT=${GOPATH}/src/k8s.io/autoscaler/vertical-pod-autoscaler/
 
-WAIT_TIME=10
+WAIT_TIME=50
 curstatus=$(await_for_controllers "$WAIT_TIME")
 if [[ "$curstatus" == "all" ]];
 then


### PR DESCRIPTION
Increase the retry WAIT_TIME for CI e2e tests. It takes a longer time for CI clusters to create controllers.