### PR TITLE
Update registry-setup/main.go

### DIFF
--- a/test/registry-setup/main.go
+++ b/test/registry-setup/main.go
@@ -19,8 +19,8 @@ const (
 	ComponentPlaceholder = "${component}"
 
 	// The matching component names in CI for the operator, operand and the operator registry image.
-	OperatorName = "openshift-vertical-pod-autoscaler-operator"
-	OperandName  = "openshift-vertical-pod-autoscaler"
+	OperatorName = "vertical-pod-autoscaler-operator"
+	OperandName  = "vertical-pod-autoscaler"
 	RegistryName = "vpa-operator-registry"
 )
 


### PR DESCRIPTION
	// The matching component names in CI for the operator, operand and the operator registry images should be the same as the targets in https://github.com/openshift/release/blob/a583f76a3b5c7741e4c215a8d2c728d775aa6818[…]operator/openshift-vertical-pod-autoscaler-operator-master.yaml
	OperatorName = "vertical-pod-autoscaler-operator"
	OperandName  = "vertical-pod-autoscaler"
	RegistryName = "vpa-operator-registry"