### PR TITLE
Bug 1974567: Remove unneeded run-level from namespace in manual install manifests

### DIFF
--- a/install/deploy/00_namespace.yaml
+++ b/install/deploy/00_namespace.yaml
@@ -5,4 +5,3 @@ metadata:
   name: openshift-vertical-pod-autoscaler
   labels:
     name: openshift-vertical-pod-autoscaler
-    openshift.io/run-level: "1"

--- a/install/deploy/03_deployment.yaml
+++ b/install/deploy/03_deployment.yaml
@@ -49,7 +49,6 @@ spec:
       restartPolicy: Always
       securityContext:
         runAsNonRoot: true
-        runAsUser: 65534
       tolerations:
       - key: "node-role.kubernetes.io/master"
         operator: "Exists"


### PR DESCRIPTION
According to https://bugzilla.redhat.com/show_bug.cgi?id=1805488, only components which must run before the SCC controller starts should use run-level 1. VPA is fine to run with the restricted SCC.