### PR TITLE
update the go.mod by go mod tidy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/openshift/api v0.0.0-20210105115604-44119421ec6b
 	github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47
 	github.com/openshift/cluster-version-operator v3.11.1-0.20190615031553-b0250fa556f6+incompatible
-	github.com/openshift/kubernetes-autoscaler v3.11.1-0.20210323190622-f31cb40e6a33+incompatible // indirect
 	github.com/stretchr/testify v1.6.1
 	k8s.io/api v0.20.4
 	k8s.io/apimachinery v0.20.5

--- a/go.sum
+++ b/go.sum
@@ -360,10 +360,6 @@ github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47 h1:+TEY29DK0Xh
 github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47/go.mod h1:u7NRAjtYVAKokiI9LouzTv4mhds8P4S1TwdVAfbjKSk=
 github.com/openshift/cluster-version-operator v3.11.1-0.20190615031553-b0250fa556f6+incompatible h1:EKyed1xVjLehFsatqR085/dr1MxSHSMLEmpwCpirV3s=
 github.com/openshift/cluster-version-operator v3.11.1-0.20190615031553-b0250fa556f6+incompatible/go.mod h1:0BbpR1mrN0F2ZRae5N1XHcytmkvVPaeKgSQwRRBWugc=
-github.com/openshift/kubernetes-autoscaler v3.11.1-0.20200605183414-17146d48bae8+incompatible h1:06LOT53/DHsEkAIxokTMJIbtp/rE4ZHHNJuvcHUboJ0=
-github.com/openshift/kubernetes-autoscaler v3.11.1-0.20200605183414-17146d48bae8+incompatible/go.mod h1:a8ziH+Nu44aIdgaZbvvisnEYz+JuI7d8vaW2bIE7P3k=
-github.com/openshift/kubernetes-autoscaler v3.11.1-0.20210323190622-f31cb40e6a33+incompatible h1:PpuJpcNDSzkWjoAFzzCr7fKhi0XSU1MHsRN8GSv6Q48=
-github.com/openshift/kubernetes-autoscaler v3.11.1-0.20210323190622-f31cb40e6a33+incompatible/go.mod h1:a8ziH+Nu44aIdgaZbvvisnEYz+JuI7d8vaW2bIE7P3k=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -66,8 +66,6 @@ github.com/openshift/client-go/config/clientset/versioned/typed/config/v1/fake
 # github.com/openshift/cluster-version-operator v3.11.1-0.20190615031553-b0250fa556f6+incompatible
 ## explicit
 github.com/openshift/cluster-version-operator/lib/resourcemerge
-# github.com/openshift/kubernetes-autoscaler v3.11.1-0.20210323190622-f31cb40e6a33+incompatible
-## explicit
 # github.com/pkg/errors v0.9.1
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0


### PR DESCRIPTION
rebase work for vpa operator https://issues.redhat.com/browse/OCPNODE-535

Signed-off-by: Qi Wang <qiwan@redhat.com>