### PR TITLE
Bug 1987136: Declare supported arches in CSV

### DIFF
--- a/manifests/4.9/vertical-pod-autoscaler.v4.9.0.clusterserviceversion.yaml
+++ b/manifests/4.9/vertical-pod-autoscaler.v4.9.0.clusterserviceversion.yaml
@@ -4,6 +4,8 @@ kind: ClusterServiceVersion
 metadata:
   name: verticalpodautoscaler.v4.9.0
   namespace: openshift-vertical-pod-autoscaler
+  labels:
+    operatorframework.io/arch.amd64: supported
   annotations:
     alm-examples: |
       [


### PR DESCRIPTION
The OperatorHub currently assumes x86-only for any operators which do
not declare any such labels.  Declaring these explicitly should make the
current status more obvious in the code, and make it easier to correctly
add further architectures when conditions warrant.
