### PR TITLE
Bug 1999951: Allow VPA to read scale subresource of any object

### DIFF
--- a/install/deploy/02_vpa-rbac.yaml
+++ b/install/deploy/02_vpa-rbac.yaml
@@ -157,6 +157,13 @@ metadata:
   name: system:vpa-target-reader
 rules:
 - apiGroups:
+  - '*'
+  resources:
+  - '*/scale'
+  verbs:
+  - get
+  - watch
+- apiGroups:
   - ""
   resources:
   - replicationcontrollers

--- a/manifests/4.9/vertical-pod-autoscaler.v4.9.0.clusterserviceversion.yaml
+++ b/manifests/4.9/vertical-pod-autoscaler.v4.9.0.clusterserviceversion.yaml
@@ -169,6 +169,14 @@ spec:
           - patch
         # from ClusterRole system:vpa-target-reader
         - apiGroups:
+          - '*'
+          resources:
+          - '*/scale'
+          verbs:
+          - get
+          - watch
+        # from ClusterRole system:vpa-target-reader
+        - apiGroups:
           - ""
           resources:
           - replicationcontrollers
@@ -301,6 +309,14 @@ spec:
           - patch
         # from ClusterRole system:vpa-target-reader
         - apiGroups:
+          - '*'
+          resources:
+          - '*/scale'
+          verbs:
+          - get
+          - watch
+        # from ClusterRole system:vpa-target-reader
+        - apiGroups:
           - ""
           resources:
           - replicationcontrollers
@@ -391,6 +407,14 @@ spec:
           - update
           - get
           - list
+          - watch
+        # from ClusterRole system:vpa-target-reader
+        - apiGroups:
+          - '*'
+          resources:
+          - '*/scale'
+          verbs:
+          - get
           - watch
         # from ClusterRole system:vpa-target-reader
         - apiGroups:


### PR DESCRIPTION
From upstream kubernetes/autoscaler/pull/3139