### PR TITLE
Update CI test to use CI dep images instead of IMAGE_FORMAT

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -118,6 +118,8 @@ then
   echo "All controllers are running"
 else
   echo "error - not all controllers are running!"
+  echo "\$ ${KUBECTL} get deployment -n openshift-vertical-pod-autoscaler"
+  ${KUBECTL} get deployment -n openshift-vertical-pod-autoscaler
   exit 1
 fi
 recommendationOnly=$(${KUBECTL} get VerticalPodAutoScalerController default -n openshift-vertical-pod-autoscaler -o jsonpath={.spec.recommendationOnly})


### PR DESCRIPTION
Also, make E2E tests a little more robust by waiting for cluster to reach the expected state after toggling between `recommendationOnly: true` and `false`.

Depends upon https://github.com/openshift/release/pull/22160