### PR TITLE
MULTIARCH-1517: Add support label for ppc64le and s390x

### DIFF
--- a/manifests/4.10/vertical-pod-autoscaler.clusterserviceversion.yaml
+++ b/manifests/4.10/vertical-pod-autoscaler.clusterserviceversion.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: openshift-vertical-pod-autoscaler
   labels:
     operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
   annotations:
     alm-examples: |
       [


### PR DESCRIPTION
Per [MULTIARCH-1517](https://issues.redhat.com/browse/MULTIARCH-1517) / [MULTIARCH-646](https://issues.redhat.com/browse/MULTIARCH-646)

Delivering VPA operator for ppc64le and s390x. The multi-arch team tested the 5 uses of VPA detailed here: https://docs.openshift.com/container-platform/4.9/nodes/pods/nodes-pods-vertical-autoscaler.html#nodes-pods-vertical-autoscaler-using-about_nodes-pods-vertical-autoscaler as well as e2e tests, on ppc64le and s390x