### PR TITLE
Add explicit security contexts to remove all privs

### DIFF
--- a/install/deploy/03_deployment.yaml
+++ b/install/deploy/03_deployment.yaml
@@ -44,6 +44,14 @@ spec:
           requests:
             cpu: 20m
             memory: 50Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
       nodeSelector:
         node-role.kubernetes.io/master: ""
       restartPolicy: Always

--- a/install/olm/registry/registry-deployment.yaml
+++ b/install/olm/registry/registry-deployment.yaml
@@ -25,6 +25,14 @@ spec:
         envFrom:
         - configMapRef:
             name: vpa-operator-registry-env
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - name: workdir
           mountPath: /bundle
@@ -56,6 +64,14 @@ spec:
           requests:
             cpu: 10m
             memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:

--- a/manifests/4.10/vertical-pod-autoscaler.clusterserviceversion.yaml
+++ b/manifests/4.10/vertical-pod-autoscaler.clusterserviceversion.yaml
@@ -529,6 +529,14 @@ spec:
                   requests:
                     cpu: 20m
                     memory: 50Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
               nodeSelector:
                 node-role.kubernetes.io/master: ""
               restartPolicy: Always

--- a/pkg/controller/verticalpodautoscaler/verticalpodautoscaler_controller.go
+++ b/pkg/controller/verticalpodautoscaler/verticalpodautoscaler_controller.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/tools/reference"
 	"k8s.io/klog"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -712,6 +713,16 @@ func (r *Reconciler) VPAPodSpec(vpa *autoscalingv1.VerticalPodAutoscalerControll
 					Requests: corev1.ResourceList{
 						corev1.ResourceName(corev1.ResourceCPU):    resource.MustParse("25m"),
 						corev1.ResourceName(corev1.ResourceMemory): resource.MustParse("25Mi"),
+					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					AllowPrivilegeEscalation: pointer.BoolPtr(false),
+					Capabilities: &corev1.Capabilities{
+						Drop: []corev1.Capability{"ALL"},
+					},
+					RunAsNonRoot: pointer.BoolPtr(true),
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: "RuntimeDefault",
 					},
 				},
 				TerminationMessagePath:   "/dev/termination-log",


### PR DESCRIPTION
This should fix warnings showing up in CI and operator logs. For example:
```
Warning: would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (containers "mutate-csv-and-generate-sqlite-db", "vpa-operator-registry" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (containers "mutate-csv-and-generate-sqlite-db", "vpa-operator-registry" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or containers "mutate-csv-and-generate-sqlite-db", "vpa-operator-registry" must set securityContext.runAsNonRoot=true), seccompProfile (pod or containers "mutate-csv-and-generate-sqlite-db", "vpa-operator-registry" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```