### PR TITLE
Add read permission of argocds/scale to vpa-recommender SA

### DIFF
--- a/install/deploy/02_vpa-rbac.yaml
+++ b/install/deploy/02_vpa-rbac.yaml
@@ -200,6 +200,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - argocds/scale
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
How to reproduce this issue is here https://github.com/openshift/vertical-pod-autoscaler-operator/issues/124. 

But not sure whether the manifests/4.x/vertical-pod-autoscaler.clusterserviceversion.yaml needs to be changed or not as I thought it is generated automatically.