### PR TITLE
[release-4.10] OCPBUGS-2662: Fix E2E CI tests by making currentCSV match CSV file

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -67,7 +67,7 @@ GOPATH="$(mktemp -d)"
 export GOPATH
 echo $GOPATH
 AUTOSCALER_PKG="github.com/openshift/kubernetes-autoscaler"
-RELEASE_VERSION="release-4.10"
+RELEASE_VERSION="release-4.9"
 echo "Get the github.com/openshift/kubernetes-autoscaler package!"
 # GO111MODULE=off go get -u -d "${AUTOSCALER_PKG}/..."
 mkdir -p ${GOPATH}/src/k8s.io

--- a/manifests/vertical-pod-autoscaler.package.yaml
+++ b/manifests/vertical-pod-autoscaler.package.yaml
@@ -2,5 +2,5 @@
 packageName: vertical-pod-autoscaler
 channels:
 - name: stable
-  currentCSV: verticalpodautoscaler
+  currentCSV: verticalpodautoscaler.v4.10.0
 defaultChannel: stable


### PR DESCRIPTION
The manifest change only affects a manual build or the builds used for E2E tests. Customer-facing builds use generated manifests and are not affected by this change.

Also, the upstream E2E tests were broken for 4.10 since this fix PR did not merge prior to our upstream rebase for 4.10: https://github.com/kubernetes/autoscaler/pull/4771

So this fix will use the 4.9 code only for the E2E tests (not for anything else).