### PR TITLE
Add manifest-diff-upstream to help keep VPA Operator manifests in sync with the VPA operand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,8 @@ vet: ## Apply go vet to all go files
 	hack/go-vet.sh ./...
 
 .PHONY: manifest-diff
-manifest-diff: build-testutil ## Compare permissions and CRDs from OLM manifests and install/*.yaml
+manifest-diff: build-testutil ## Compare permissions and CRDs from upstream manifests, OLM manifests and install/*.yaml
+	hack/manifest-diff-upstream.sh
 	hack/manifest-diff.sh
 
 .PHONY: build-testutil

--- a/hack/filter-upstream-rbac.jq
+++ b/hack/filter-upstream-rbac.jq
@@ -1,0 +1,20 @@
+def indexof(f):
+  first(range(0;length) as $i
+        | select(.[$i]|f) | $i) // null;
+
+# Find the ClusterRoleBinding with the typo name
+(.items | indexof(.kind=="ClusterRoleBinding" and .metadata.name=="system:vpa-evictionter-binding")) as $i |
+# Fix the typo
+if $i then .items[$i].metadata.name |= "system:vpa-evictioner-binding" else . end |
+# insert two missing ServiceAccounts after the ClusterRoleBinding with the typo name 
+if $i then (.items |= .[0:$i+1] + [
+        {apiVersion: "v1", kind: "ServiceAccount", metadata: {name: "vpa-updater", namespace: "kube-system"}},
+        {apiVersion: "v1", kind: "ServiceAccount", metadata: {name: "vpa-recommender", namespace: "kube-system"}}
+      ] + .[$i+1:]) else . end |
+# Add OpenShift-specific deploymentconfigs perms to vpa-target-reader
+(.items[] | select(.kind=="ClusterRole" and .metadata.name=="system:vpa-target-reader")).rules += [ {
+        apiGroups: [ "apps.openshift.io" ],
+        resources: [ "deploymentconfigs", "deploymentconfigs/scale" ],
+        verbs: [ "get", "list", "watch" ] } ] |
+# We use namespace openshift-vertical-pod-autoscaler instead of kube-system. Replace all namespaces
+walk(if type == "object" and has("namespace") then .namespace="openshift-vertical-pod-autoscaler" else . end)

--- a/hack/manifest-diff-upstream.sh
+++ b/hack/manifest-diff-upstream.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+
+# This check makes sure that the install manifests for a manual install (in install/deploy/)
+# are in sync with the upstream install manifests. It should detect when upstream manifests
+# have been modified for bug fixes, new features, etc. so that the OpenShift VPA operator
+# can likewise be updated so that the VPA code and manifests stay in sync.
+
+operand_branch="release-4.12"
+repo_base="$( dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )")"
+repo_name=$(basename "${repo_base}")
+upstream_manifest_url_prefix="https://raw.githubusercontent.com/openshift/kubernetes-autoscaler/$operand_branch/vertical-pod-autoscaler/deploy"
+
+cd "${repo_base}"
+if ! [ -x bin/json2yaml -a -x bin/yaml2json ]; then
+  echo "Missing test utilities bin/json2yaml and/or bin/yaml2json. 'make build-testutil' must be run first"
+  exit 1
+fi
+if [ "$NO_DOCKER" = "1" -o -n "$IS_CONTAINER" ]; then
+  exitcode=0
+  outdir="$(mktemp --tmpdir -d manifest-diff.XXXXXXXXXX)"
+  trap "rm -rf '${outdir}'" EXIT
+  mkdir "${outdir}/upstream/"
+
+  # Step 1: Compare RBAC from install/deploy/02_vpa-rbac.yaml with upstream RBAC
+  upstream_filename="vpa-rbac.yaml"
+  upstream_file="${outdir}/upstream/${upstream_filename}"
+  if ! curl -s "$upstream_manifest_url_prefix/$upstream_filename" > "$upstream_file"; then
+    exitcode=$?
+    echo "Failed to get $upstream_manifest_url_prefix/$upstream_filename"
+  fi
+  rbacfile="install/deploy/02_vpa-rbac.yaml"
+  out1="${outdir}/rbac-from-upstream-$(basename "$upstream_file")"
+  out2="${outdir}/rbac-from-$(basename "$rbacfile")"
+
+  sed -f hack/yamls2list.sed < "$upstream_file" | bin/yaml2json  | jq -f hack/filter-upstream-rbac.jq | bin/json2yaml > "$out1"
+  # RBAC items related to the OpenShift VPA operator should be removed prior to comparison
+  sed -f hack/yamls2list.sed < "$rbacfile" | bin/yaml2json  | jq 'del(.items[] | select(.metadata.name == "vertical-pod-autoscaler-operator"))' | bin/json2yaml > "$out2"
+
+  if ! diff -q "$out1" "$out2"; then
+    echo
+    echo "Normalized $upstream_file:"
+    echo
+    cat "$out1"
+    echo
+    echo "Normalized $rbacfile:"
+    echo
+    cat "$out2"
+    echo
+    echo diff -u "$out1" "$out2"
+    echo
+    diff -u "$out1" "$out2"
+    echo
+    echo "$0 failed. Permissions not equivalent in $rbacfile and $upstream_file"
+    echo "If changes are made to $upstream_file, equivalent changes should be made to $rbacfile"
+    echo "If OpenShift-specific changes are made to $rbacfile, those changes should be represented in hack/filter-upstream-rbac.jq so that a transformed upstream rbac will match the downstream changed version."
+    echo
+    exitcode=1
+  fi
+
+  # Step 2: Compare the VPA CRD in install/deploy/ with the one from manifests/
+  upstream_filename="vpa-v1-crd-gen.yaml"
+  upstream_file="${outdir}/upstream/${upstream_filename}"
+  echo --- > "$upstream_file"
+  if ! curl -s "$upstream_manifest_url_prefix/$upstream_filename" >> "$upstream_file"; then
+    exitcode=$?
+    echo "Failed to get $upstream_manifest_url_prefix/$upstream_filename"
+  fi
+  crdfile="install/deploy/05_vpa-crd.yaml"
+  out1="${outdir}/crd-from-upstream-$(basename "$upstream_file")"
+  out2="${outdir}/crd-from-$(basename "$crdfile")"
+
+  sed -f hack/yamls2list.sed < "$upstream_file" | bin/yaml2json | jq '.items[] | select(.kind=="CustomResourceDefinition" and .metadata.name=="verticalpodautoscalers.autoscaling.k8s.io")' | bin/json2yaml > "$out1"
+  # re-add fixed typo (trailing double quote char) to make it match. The jq command can be removed as soon the upstream typo is fixed
+  bin/yaml2json < "$crdfile" | jq 'walk(if type == "object" and has("description") and (.description|startswith("Kind of the referent")) then .description+="\"" else . end)' | bin/json2yaml > "$out2"
+  if ! diff -q "$out1" "$out2"; then
+    echo
+    echo "Normalized $upstream_file:"
+    echo
+    cat "$out1"
+    echo
+    echo "Normalized $crdfile:"
+    echo
+    cat "$out2"
+    echo
+    echo diff -u "$out1" "$out2"
+    echo
+    diff -u "$out1" "$out2"
+    echo
+    echo "$0 failed. CRDs don't match: $crdfile and $upstream_manifest_url_prefix/$upstream_filename"
+    echo "If changes are made to the upstream CRD, equivalent changes should be made to $crdfile."
+    echo
+    exitcode=1
+  fi
+
+  # Step 3: Compare the VPA Checkpoint CRD in install/deploy/ with the one from manifests/
+  crdfile="install/deploy/06_vpacheckpoint-crd.yaml"
+  out2="${outdir}/crd-from-$(basename "$crdfile")"
+
+  sed -f hack/yamls2list.sed < "$upstream_file" | bin/yaml2json | jq '.items[] | select(.kind=="CustomResourceDefinition" and .metadata.name=="verticalpodautoscalercheckpoints.autoscaling.k8s.io")' | bin/json2yaml > "$out1"
+  bin/yaml2json < "$crdfile" | bin/json2yaml > "$out2"
+  if ! diff -q "$out1" "$out2"; then
+    echo
+    echo "Normalized $upstream_file:"
+    echo
+    cat "$out1"
+    echo
+    echo "Normalized $crdfile:"
+    echo
+    cat "$out2"
+    echo
+    echo diff -u "$out1" "$out2"
+    echo
+    diff -u "$out1" "$out2"
+    echo
+    echo "$0 failed. CRDs don't match: $crdfile and $upstream_manifest_url_prefix/$upstream_filename"
+    echo "If changes are made to the upstream CRD, equivalent changes should be made to $crdfile."
+    echo
+    exitcode=1
+  fi
+  exit $exitcode
+else
+  podman run --rm \
+    --env IS_CONTAINER=TRUE \
+    --volume "${repo_base}:/go/src/github.com/openshift/${repo_name}:z" \
+    --workdir "/go/src/github.com/openshift/${repo_name}" \
+    registry.ci.openshift.org/openshift/release:golang-1.18 \
+    ./hack/manifest-diff.sh "${@}"
+fi;

--- a/hack/manifest-diff.sh
+++ b/hack/manifest-diff.sh
@@ -62,7 +62,7 @@ if [ "$NO_DOCKER" = "1" -o -n "$IS_CONTAINER" ]; then
     exitcode=1
   fi
 
-  # Step 4: Compare the VPA CRD in install/deploy/ with the one from manifests/
+  # Step 4: Compare the VPA Checkpoint CRD in install/deploy/ with the one from manifests/
   crdfile="manifests/stable/vpacheckpoint-v1.crd.yaml"
   if ! diff -wu install/deploy/06_vpacheckpoint-crd.yaml "$crdfile"; then
     echo
@@ -78,6 +78,6 @@ else
     --env IS_CONTAINER=TRUE \
     --volume "${repo_base}:/go/src/github.com/openshift/${repo_name}:z" \
     --workdir "/go/src/github.com/openshift/${repo_name}" \
-    openshift/origin-release:golang-1.15 \
+    registry.ci.openshift.org/openshift/release:golang-1.18 \
     ./hack/manifest-diff.sh "${@}"
 fi;

--- a/install/deploy/06_vpacheckpoint-crd.yaml
+++ b/install/deploy/06_vpacheckpoint-crd.yaml
@@ -210,3 +210,9 @@ spec:
         type: object
     served: true
     storage: false
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/manifests/stable/vpacheckpoint-v1.crd.yaml
+++ b/manifests/stable/vpacheckpoint-v1.crd.yaml
@@ -210,3 +210,9 @@ spec:
         type: object
     served: true
     storage: false
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
Currently we have no check to detect when a change is made to the upstream VPA which requires a manifest change to the VPA operator. This PR seeks to remedy that deficiency. This new check will fetch 2 key manifests from the OpenShift fork of the Kubernetes Autoscaling repo: The RBAC objects and the CRD objects.

The check detected that we were missing the status stanza of the VPA Checkpoint CRD, so this PR also adds that stanza so that this PR can pass.