### PR TITLE
fix naming convention

### DIFF
--- a/manifests/art.yaml
+++ b/manifests/art.yaml
@@ -5,7 +5,7 @@ updates:
   update_list:
   # replace metadata.name value
   - search: "verticalpodautoscaler.v{MAJOR}.{MINOR}.0"
-    replace: "verticalpodautoscaler.{FULL_VER}"
+    replace: "verticalpodautoscaler.v{FULL_VER}"
   - search: "version: {MAJOR}.{MINOR}.0"
     replace: "version: {FULL_VER}"
   - search: 'olm.skipRange: ">=4.5.0 <{MAJOR}.{MINOR}.0"'


### PR DESCRIPTION
there is a warning reported in CVP check for 4.12
http://external-ci-coldstorage.datahub.redhat.com/cvp/cvp-redhat-operator-bundle-image-validation-test/ose-vertical-pod-autoscaler-operator-metadata-container-v4.12.0.202211081106.p0.ga64bda3.assembly.stream-1/f734657d-877b-46d7-8c1d-30daff872ac6/operator-metadata-linting-bundle-image-output.txt
I think this could be a common issue, so pr against master can cherry-pick to 4.12 branch later.