### PR TITLE
PODAUTO-96: Exclude vendor and tests from snyk scans to reduce noise

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,4 @@
+exclude:
+  global:
+    - "vendor/**"
+    - "**/*_test.go"


### PR DESCRIPTION
We've been getting a lot of noise on snyk scans from deps and tests, so for now we need to exclude those files.