### PR TITLE
PODAUTO-102: Add NodeSelector and Tolerations fields to deploymentoverrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,7 +284,7 @@ operator-registry-image:
 	mkdir -p $(MANIFESTS_DIR)
 	cp manifests/*.package.yaml $(MANIFESTS_DIR)/
 	cp -r manifests/stable $(MANIFESTS_DIR)/
-	find $(MANIFESTS_DIR)/stable -type f ! -name '*.yaml' | xargs rm -v
+	find $(MANIFESTS_DIR)/stable -type f ! -name '*.yaml' | xargs -r rm -v
 
 	test -n "$(LOCAL_OPERATOR_IMAGE)" || { echo "Unable to find operator image"; false; }
 	test -n "$(LOCAL_OPERAND_IMAGE)" || { echo "Unable to find operand image"; false; }

--- a/install/deploy/01_vpacontroller.crd.yaml
+++ b/install/deploy/01_vpacontroller.crd.yaml
@@ -109,6 +109,57 @@ spec:
                                 type: object
                             type: object
                         type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: Override the NodeSelector of the deployment's
+                          pod. This allows, for example, for the VPA controllers to
+                          be run on non-master nodes
+                        type: object
+                      tolerations:
+                        description: Override the Tolerations of the deployment's
+                          pod. This allows, for example, for the VPA controllers to
+                          be run on non-master nodes with a specific taint
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified,
+                                allowed values are NoSchedule, PreferNoSchedule and
+                                NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship
+                                to the value. Valid operators are Exists and Equal.
+                                Defaults to Equal. Exists is equivalent to wildcard
+                                for value, so that a pod can tolerate all taints of
+                                a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
                     type: object
                   recommender:
                     description: recommender is the deployment overrides for the VPA's
@@ -179,6 +230,57 @@ spec:
                                 type: object
                             type: object
                         type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: Override the NodeSelector of the deployment's
+                          pod. This allows, for example, for the VPA controllers to
+                          be run on non-master nodes
+                        type: object
+                      tolerations:
+                        description: Override the Tolerations of the deployment's
+                          pod. This allows, for example, for the VPA controllers to
+                          be run on non-master nodes with a specific taint
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified,
+                                allowed values are NoSchedule, PreferNoSchedule and
+                                NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship
+                                to the value. Valid operators are Exists and Equal.
+                                Defaults to Equal. Exists is equivalent to wildcard
+                                for value, so that a pod can tolerate all taints of
+                                a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
                     type: object
                   updater:
                     description: updater is the deployment overrides for the VPA's
@@ -249,6 +351,57 @@ spec:
                                 type: object
                             type: object
                         type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: Override the NodeSelector of the deployment's
+                          pod. This allows, for example, for the VPA controllers to
+                          be run on non-master nodes
+                        type: object
+                      tolerations:
+                        description: Override the Tolerations of the deployment's
+                          pod. This allows, for example, for the VPA controllers to
+                          be run on non-master nodes with a specific taint
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified,
+                                allowed values are NoSchedule, PreferNoSchedule and
+                                NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship
+                                to the value. Valid operators are Exists and Equal.
+                                Defaults to Equal. Exists is equivalent to wildcard
+                                for value, so that a pod can tolerate all taints of
+                                a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
                     type: object
                 type: object
               minReplicas:

--- a/manifests/stable/vertical-pod-autoscaler-controller.crd.yaml
+++ b/manifests/stable/vertical-pod-autoscaler-controller.crd.yaml
@@ -109,6 +109,57 @@ spec:
                                 type: object
                             type: object
                         type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: Override the NodeSelector of the deployment's
+                          pod. This allows, for example, for the VPA controllers to
+                          be run on non-master nodes
+                        type: object
+                      tolerations:
+                        description: Override the Tolerations of the deployment's
+                          pod. This allows, for example, for the VPA controllers to
+                          be run on non-master nodes with a specific taint
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified,
+                                allowed values are NoSchedule, PreferNoSchedule and
+                                NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship
+                                to the value. Valid operators are Exists and Equal.
+                                Defaults to Equal. Exists is equivalent to wildcard
+                                for value, so that a pod can tolerate all taints of
+                                a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
                     type: object
                   recommender:
                     description: recommender is the deployment overrides for the VPA's
@@ -179,6 +230,57 @@ spec:
                                 type: object
                             type: object
                         type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: Override the NodeSelector of the deployment's
+                          pod. This allows, for example, for the VPA controllers to
+                          be run on non-master nodes
+                        type: object
+                      tolerations:
+                        description: Override the Tolerations of the deployment's
+                          pod. This allows, for example, for the VPA controllers to
+                          be run on non-master nodes with a specific taint
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified,
+                                allowed values are NoSchedule, PreferNoSchedule and
+                                NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship
+                                to the value. Valid operators are Exists and Equal.
+                                Defaults to Equal. Exists is equivalent to wildcard
+                                for value, so that a pod can tolerate all taints of
+                                a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
                     type: object
                   updater:
                     description: updater is the deployment overrides for the VPA's
@@ -249,6 +351,57 @@ spec:
                                 type: object
                             type: object
                         type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: Override the NodeSelector of the deployment's
+                          pod. This allows, for example, for the VPA controllers to
+                          be run on non-master nodes
+                        type: object
+                      tolerations:
+                        description: Override the Tolerations of the deployment's
+                          pod. This allows, for example, for the VPA controllers to
+                          be run on non-master nodes with a specific taint
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified,
+                                allowed values are NoSchedule, PreferNoSchedule and
+                                NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship
+                                to the value. Valid operators are Exists and Equal.
+                                Defaults to Equal. Exists is equivalent to wildcard
+                                for value, so that a pod can tolerate all taints of
+                                a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
                     type: object
                 type: object
               minReplicas:

--- a/pkg/apis/autoscaling/v1/verticalpodautoscalercontroller_types.go
+++ b/pkg/apis/autoscaling/v1/verticalpodautoscalercontroller_types.go
@@ -52,6 +52,16 @@ type DeploymentOverride struct {
 	// that is actually running the operand
 	// +optional
 	Container ContainerOverride `json:"container"`
+
+	// Override the NodeSelector of the deployment's pod. This allows, for example, for the VPA controllers
+	// to be run on non-master nodes
+	// +optional
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+
+	// Override the Tolerations of the deployment's pod. This allows, for example, for the VPA controllers
+	// to be run on non-master nodes with a specific taint
+	// +optional
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 }
 
 // ContainerOverride defines fields that can be overridden for a given container

--- a/pkg/controller/verticalpodautoscaler/verticalpodautoscaler_controller.go
+++ b/pkg/controller/verticalpodautoscaler/verticalpodautoscaler_controller.go
@@ -774,6 +774,16 @@ func (r *Reconciler) RecommenderControllerPodSpec(vpa *autoscalingv1.VerticalPod
 		spec.Containers[0].Args = append(spec.Containers[0].Args, vpa.Spec.DeploymentOverrides.Recommender.Container.Args...)
 	}
 
+	// Replace node selector, if specified
+	if len(vpa.Spec.DeploymentOverrides.Recommender.NodeSelector) > 0 {
+		spec.NodeSelector = vpa.Spec.DeploymentOverrides.Recommender.NodeSelector
+	}
+
+	// Replace tolerations, if specified
+	if len(vpa.Spec.DeploymentOverrides.Recommender.Tolerations) > 0 {
+		spec.Tolerations = vpa.Spec.DeploymentOverrides.Recommender.Tolerations
+	}
+
 	return spec
 }
 
@@ -791,6 +801,17 @@ func (r *Reconciler) UpdaterControllerPodSpec(vpa *autoscalingv1.VerticalPodAuto
 	if len(vpa.Spec.DeploymentOverrides.Updater.Container.Args) > 0 {
 		spec.Containers[0].Args = append(spec.Containers[0].Args, vpa.Spec.DeploymentOverrides.Updater.Container.Args...)
 	}
+
+	// Replace node selector, if specified
+	if len(vpa.Spec.DeploymentOverrides.Updater.NodeSelector) > 0 {
+		spec.NodeSelector = vpa.Spec.DeploymentOverrides.Updater.NodeSelector
+	}
+
+	// Replace tolerations, if specified
+	if len(vpa.Spec.DeploymentOverrides.Updater.Tolerations) > 0 {
+		spec.Tolerations = vpa.Spec.DeploymentOverrides.Updater.Tolerations
+	}
+
 	return spec
 }
 
@@ -807,6 +828,16 @@ func (r *Reconciler) AdmissionControllerPodSpec(vpa *autoscalingv1.VerticalPodAu
 	// Append user args to our container args
 	if len(vpa.Spec.DeploymentOverrides.Admission.Container.Args) > 0 {
 		spec.Containers[0].Args = append(spec.Containers[0].Args, vpa.Spec.DeploymentOverrides.Admission.Container.Args...)
+	}
+
+	// Replace node selector, if specified
+	if len(vpa.Spec.DeploymentOverrides.Admission.NodeSelector) > 0 {
+		spec.NodeSelector = vpa.Spec.DeploymentOverrides.Admission.NodeSelector
+	}
+
+	// Replace tolerations, if specified
+	if len(vpa.Spec.DeploymentOverrides.Admission.Tolerations) > 0 {
+		spec.Tolerations = vpa.Spec.DeploymentOverrides.Admission.Tolerations
 	}
 
 	spec.Containers[0].Ports = append(spec.Containers[0].Ports, corev1.ContainerPort{


### PR DESCRIPTION
Also, clean up TestOverrideResources's flipped expected/actual ordering