### PR TITLE
PODAUTO-225: Remove go mod verify from Dockerfile

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -11,7 +11,11 @@ COPY go.sum go.sum
 # since we use vendoring we don't need to redownload our dependencies every time. Instead we can simply
 # reuse our vendored directory and verify everything is good. If not we can abort here and ask for a revendor.
 COPY vendor vendor/
-RUN go mod verify
+
+# TODO(jkyros): go mod verify talks to the internet to check hashes, and it breaks in our disconnected
+# build environment without access to the go proxy. Maybe there is a mod cache or something we can make
+# it use in the build environment, but until then, turn it off.
+# RUN  go mod verify
 
 # Copy the go source
 COPY cmd/main.go cmd/main.go


### PR DESCRIPTION
- We run our builds in a disconnected environment 
- `go mod verify`  tries to connect to the internet to check modules hashes
- that doesn't work in our disconnected environment: 
```2024-08-29 07:08:17,246 - atomic_reactor.tasks.binary_container_build - INFO - go: github.com/beorn7/perks@v1.0.1: Get "https://proxy.golang.org/github.com/beorn7/perks/@v/v1.0.1.mod": Forbidden``` (that's just the first module, it starts at the beginning) 

This PR just removes `go mod verify` to unblock builds. 

Today I learned :smile: 