### PR TITLE
PODAUTO-225: Re-enable VPA alm-example in CSV and add spec descriptors

### DIFF
--- a/bundle/manifests/vertical-pod-autoscaler.clusterserviceversion.yaml
+++ b/bundle/manifests/vertical-pod-autoscaler.clusterserviceversion.yaml
@@ -55,7 +55,7 @@ metadata:
     categories: OpenShift Optional
     certifiedLevel: Primed
     containerImage: quay.io/openshift/origin-vertical-pod-autoscaler-operator:4.18.0
-    createdAt: "2024-09-24T22:10:11Z"
+    createdAt: "2024-09-25T02:20:09Z"
     description: An operator to run the OpenShift Vertical Pod Autoscaler. Vertical
       Pod Autoscaler (VPA) can be configured to monitor a workload's resource utilization,
       and then adjust its CPU and memory limits by updating the pod (future) or restarting
@@ -153,6 +153,81 @@ spec:
       - kind: Service
         name: ""
         version: v1
+      specDescriptors:
+      - displayName: Target Ref
+        path: targetRef
+      - displayName: API Version
+        path: targetRef.apiVersion
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Kind
+        path: targetRef.kind
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Name
+        path: targetRef.name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Recommenders
+        path: recommenders
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:array
+      - displayName: Recommender Name
+        path: recommenders[0].name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Resource Policy
+        path: resourcePolicy
+      - displayName: Container Policies
+        path: resourcePolicy.containerPolicies
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:array
+      - displayName: Container Name
+        path: resourcePolicy.containerPolicies[0].containerName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Controlled Resources
+        path: resourcePolicy.containerPolicies[0].controlledResources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:array
+      - displayName: Controlled Values
+        path: resourcePolicy.containerPolicies[0].controlledValues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:select
+      - displayName: Max Allowed
+        path: resourcePolicy.containerPolicies[0].maxAllowed
+      - displayName: Min Allowed
+        path: resourcePolicy.containerPolicies[0].minAllowed
+      - displayName: Mode
+        path: resourcePolicy.containerPolicies[0].mode
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:select
+      - displayName: Update Policy
+        path: updatePolicy
+      - displayName: Eviction Requirements
+        path: updatePolicy.evictionRequirements
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:array
+      - displayName: Eviction Change Requirement
+        path: updatePolicy.evictionRequirements[0].changeRequirement
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:select
+      - displayName: Resources
+        path: updatePolicy.evictionRequirements[0].resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:array
+      - displayName: Resource Name
+        path: updatePolicy.evictionRequirements[0].resources[0]
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Minimum Replicas
+        path: updatePolicy.minReplicas
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+      - displayName: Update Mode
+        path: updatePolicy.updateMode
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:select
       version: v1
     - kind: VerticalPodAutoscaler
       name: verticalpodautoscalers.autoscaling.k8s.io

--- a/bundle/manifests/vertical-pod-autoscaler.clusterserviceversion.yaml
+++ b/bundle/manifests/vertical-pod-autoscaler.clusterserviceversion.yaml
@@ -5,6 +5,39 @@ metadata:
     alm-examples: |-
       [
         {
+          "apiVersion": "autoscaling.k8s.io/v1",
+          "kind": "VerticalPodAutoscaler",
+          "metadata": {
+            "name": "myapp-vpa"
+          },
+          "spec": {
+            "resourcePolicy": {
+              "containerPolicies": [
+                {
+                  "containerName": "*",
+                  "controlledResources": [
+                    "cpu",
+                    "memory"
+                  ],
+                  "maxAllowed": {
+                    "cpu": 1,
+                    "memory": "500Mi"
+                  },
+                  "minAllowed": {
+                    "cpu": "100m",
+                    "memory": "50Mi"
+                  }
+                }
+              ]
+            },
+            "targetRef": {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "name": "myapp-deployment"
+            }
+          }
+        },
+        {
           "apiVersion": "autoscaling.openshift.io/v1",
           "kind": "VerticalPodAutoscalerController",
           "metadata": {
@@ -22,7 +55,7 @@ metadata:
     categories: OpenShift Optional
     certifiedLevel: Primed
     containerImage: quay.io/openshift/origin-vertical-pod-autoscaler-operator:4.18.0
-    createdAt: "2024-09-06T21:50:13Z"
+    createdAt: "2024-09-24T22:10:11Z"
     description: An operator to run the OpenShift Vertical Pod Autoscaler. Vertical
       Pod Autoscaler (VPA) can be configured to monitor a workload's resource utilization,
       and then adjust its CPU and memory limits by updating the pod (future) or restarting
@@ -569,6 +602,8 @@ spec:
                 env:
                 - name: RELATED_IMAGE_VPA
                   value: quay.io/openshift/origin-vertical-pod-autoscaler:latest
+                - name: RELEASE_VERSION
+                  value: 0.0.1-snapshot
                 - name: WATCH_NAMESPACE
                   valueFrom:
                     fieldRef:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -38,6 +38,8 @@ spec:
         args:
         - --leader-elect
         env:
+        - name: RELATED_IMAGE_VPA
+          value: quay.io/openshift/origin-vertical-pod-autoscaler:latest
         - name: RELEASE_VERSION
           value: "0.0.1-snapshot"
         - name: WATCH_NAMESPACE
@@ -48,8 +50,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: RELATED_IMAGE_VPA
-          value: quay.io/openshift/origin-vertical-pod-autoscaler:latest
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/manifests/bases/vertical-pod-autoscaler.clusterserviceversion.yaml
+++ b/config/manifests/bases/vertical-pod-autoscaler.clusterserviceversion.yaml
@@ -67,6 +67,81 @@ spec:
       - kind: Service
         name: ""
         version: v1
+      specDescriptors:
+      - displayName: Target Ref
+        path: targetRef
+      - displayName: API Version
+        path: targetRef.apiVersion
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Kind
+        path: targetRef.kind
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Name
+        path: targetRef.name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Recommenders
+        path: recommenders
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:array
+      - displayName: Recommender Name
+        path: recommenders[0].name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Resource Policy
+        path: resourcePolicy
+      - displayName: Container Policies
+        path: resourcePolicy.containerPolicies
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:array
+      - displayName: Container Name
+        path: resourcePolicy.containerPolicies[0].containerName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Controlled Resources
+        path: resourcePolicy.containerPolicies[0].controlledResources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:array
+      - displayName: Controlled Values
+        path: resourcePolicy.containerPolicies[0].controlledValues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:select
+      - displayName: Max Allowed
+        path: resourcePolicy.containerPolicies[0].maxAllowed
+      - displayName: Min Allowed
+        path: resourcePolicy.containerPolicies[0].minAllowed
+      - displayName: Mode
+        path: resourcePolicy.containerPolicies[0].mode
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:select
+      - displayName: Update Policy
+        path: updatePolicy
+      - displayName: Eviction Requirements
+        path: updatePolicy.evictionRequirements
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:array
+      - displayName: Eviction Change Requirement
+        path: updatePolicy.evictionRequirements[0].changeRequirement
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:select
+      - displayName: Resources
+        path: updatePolicy.evictionRequirements[0].resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:array
+      - displayName: Resource Name
+        path: updatePolicy.evictionRequirements[0].resources[0]
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Minimum Replicas
+        path: updatePolicy.minReplicas
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+      - displayName: Update Mode
+        path: updatePolicy.updateMode
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:select
       version: v1
     - description: Represents VPA checkpoints used by the VPA controllers to manage
         workloads

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,8 +1,6 @@
 ## Append samples of your project ##
 resources:
 - autoscaling_v1_verticalpodautoscalercontroller.yaml
-# including the below commented item will make it appear in the alm-examples annotations in the CSV (and suppress the warning)
-# but this will make operator-sdk apply the CR when installing the operator, which we don't want
-# - autoscaling_v1_verticalpodautoscaler.yaml
-#
+- autoscaling_v1_verticalpodautoscaler.yaml
+
 # +kubebuilder:scaffold:manifestskustomizesamples


### PR DESCRIPTION
This commit re-enables the VPA example in the CSV for the OCP console to use. Turns out the VPA is a "supported resource" and operator-sdk adds your supported resource examples to the bundle regardless if it's actually an owned resource or not. This commit simply uncomments the sample, and manually removes it from the bundle folder after we generate the bundle. 

This is what I am talking about: https://github.com/operator-framework/operator-registry/blob/c8307cac2e6ea71b3719e6d5a5850dd639da296f/pkg/lib/bundle/supported_resources.go#L18

Operator-sdk generate bundle goes through files and writes [CRDs, Services, and "supported resources"](https://github.com/operator-framework/operator-sdk/blob/819984d4c1a51c8ff2ef6c23944554148ace0752/internal/cmd/operator-sdk/generate/internal/manifests.go#L40) to the bundle directory only. Unfortunately, we supply one of those resources in an operator-sdk project :p 

This commit also adds spec descriptors to the VPA since the scorecard test now complains about them not being present after adding an example.

Finally, this commit also fixes a bug when deploying the bundle with Make and specifying an OPERAND_IMG.