### PR TITLE
OCPBUGS-45372: Update default resource requests and QPS/Burst

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -290,6 +290,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.2.1
 CONTROLLER_TOOLS_VERSION ?= v0.14.0
+ENVTEST_VERSION ?= release-0.18
 
 # GOFLAGS is explicitly empty here so that we do not run into https://github.com/golang/go/issues/45811 on CI
 # This is set in kustomize, controller-gen, and envtest targets
@@ -311,7 +312,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOFLAGS='' GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.18
+	test -s $(LOCALBIN)/setup-envtest || GOFLAGS='' GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION)
 
 .PHONY: operator-sdk
 OPERATOR_SDK ?= $(LOCALBIN)/operator-sdk
@@ -451,7 +452,7 @@ undeploy-catalog: ## Undeploy the catalog image.
 	cd $(OLM_OUTPUT_DIR) && $(KUSTOMIZE) edit set image quay.io/openshift/origin-vertical-pod-autoscaler-operator-catalog=$(CATALOG_IMG)
 	$(KUSTOMIZE) build $(OLM_OUTPUT_DIR) | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
 	$(MAKE) delete-ns
-
+	$(MAKE) uninstall
 
 .PHONY: create_vpa_controller_cr
 create_vpa_controller_cr: ## Create a VPA CR.

--- a/bundle/manifests/vertical-pod-autoscaler.clusterserviceversion.yaml
+++ b/bundle/manifests/vertical-pod-autoscaler.clusterserviceversion.yaml
@@ -55,7 +55,7 @@ metadata:
     categories: OpenShift Optional
     certifiedLevel: Primed
     containerImage: quay.io/openshift/origin-vertical-pod-autoscaler-operator:4.18.0
-    createdAt: "2024-09-25T02:20:09Z"
+    createdAt: "2024-12-03T20:22:23Z"
     description: An operator to run the OpenShift Vertical Pod Autoscaler. Vertical
       Pod Autoscaler (VPA) can be configured to monitor a workload's resource utilization,
       and then adjust its CPU and memory limits by updating the pod (future) or restarting
@@ -688,6 +688,7 @@ spec:
                     fieldRef:
                       fieldPath: metadata.namespace
                 image: quay.io/openshift/origin-vertical-pod-autoscaler-operator:4.18.0
+                imagePullPolicy: Always
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -702,6 +703,9 @@ spec:
                   initialDelaySeconds: 5
                   periodSeconds: 10
                 resources:
+                  limits:
+                    cpu: 100m
+                    memory: 500Mi
                   requests:
                     cpu: 20m
                     memory: 50Mi

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -37,6 +37,7 @@ spec:
         - /manager
         args:
         - --leader-elect
+        imagePullPolicy: Always
         env:
         - name: VPA_OPERAND_IMAGE
           value: quay.io/openshift/origin-vertical-pod-autoscaler:latest
@@ -66,6 +67,9 @@ spec:
           requests:
             cpu: 20m
             memory: 50Mi
+          limits:
+            cpu: 100m
+            memory: 500Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/config/manifests/bases/vertical-pod-autoscaler.clusterserviceversion.yaml
+++ b/config/manifests/bases/vertical-pod-autoscaler.clusterserviceversion.yaml
@@ -217,5 +217,4 @@ spec:
   minKubeVersion: 1.11.0
   provider:
     name: Red Hat
-  replaces: verticalpodautoscaler.v4.17.0
   version: 0.0.0

--- a/internal/controller/verticalpodautoscaler/verticalpodautoscaler_controller_test.go
+++ b/internal/controller/verticalpodautoscaler/verticalpodautoscaler_controller_test.go
@@ -87,6 +87,27 @@ func includeString(list []string, item string) bool {
 	return false
 }
 
+func TestAdmissionArgs(t *testing.T) {
+	vpa := NewVerticalPodAutoscaler()
+
+	args := AdmissionPluginArgs(vpa, &Config{Namespace: TestNamespace})
+
+	expected := []string{
+		fmt.Sprintf("--kube-api-qps=%.01f", 25.0),
+		fmt.Sprintf("--kube-api-burst=%.01f", 50.0),
+		"--tls-cert-file=/data/tls-certs/tls.crt",
+		"--tls-private-key=/data/tls-certs/tls.key",
+		"--client-ca-file=/data/tls-ca-certs/service-ca.crt",
+		"--webhook-timeout-seconds=10",
+	}
+
+	for _, e := range expected {
+		if !includeString(args, e) {
+			t.Fatalf("missing arg: %s from %s", e, args)
+		}
+	}
+}
+
 func TestRecommenderArgs(t *testing.T) {
 	vpa := NewVerticalPodAutoscaler()
 

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,6 +1,9 @@
 package util
 
 import (
+	"slices"
+	"strings"
+
 	configv1 "github.com/openshift/api/config/v1"
 	cvorm "github.com/openshift/cluster-version-operator/lib/resourcemerge"
 	appsv1 "k8s.io/api/apps/v1"
@@ -79,4 +82,11 @@ func ResetProgressingTime(conds *[]configv1.ClusterOperatorStatusCondition) {
 	prog.LastTransitionTime = metav1.Now()
 
 	cvorm.SetOperatorStatusCondition(conds, *prog)
+}
+
+// ArgExists checks whether a given argument exists in a slice of arguments.
+func ArgExists(args []string, arg string) bool {
+	return slices.ContainsFunc(args, func(a string) bool {
+		return strings.HasPrefix(a, arg+"=")
+	})
 }

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -230,3 +230,52 @@ func TestResetProgressingTime(t *testing.T) {
 		})
 	}
 }
+
+func TestArgExists(t *testing.T) {
+	testCases := []struct {
+		label    string
+		args     []string
+		prefix   string
+		expected bool
+	}{
+		{
+			label:    "argument exists",
+			args:     []string{"--kube-api-qps=25.0", "--kube-api-burst=50.0"},
+			prefix:   "--kube-api-qps",
+			expected: true,
+		},
+		{
+			label:    "argument does not exist",
+			args:     []string{"--kube-api-qps=25.0", "--kube-api-burst=50.0"},
+			prefix:   "--kube-api-rate",
+			expected: false,
+		},
+		{
+			label:    "empty arguments",
+			args:     []string{},
+			prefix:   "--kube-api-qps",
+			expected: false,
+		},
+		{
+			label:    "prefix matches partially",
+			args:     []string{"--kube-api-qps=25.0", "--kube-api-burst=50.0"},
+			prefix:   "--kube-api",
+			expected: false,
+		},
+		{
+			label:    "prefix matches partially the other way",
+			args:     []string{"--kube-api-qps=25.0", "--kube-api-burst=50.0"},
+			prefix:   "kube-api-qps",
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.label, func(t *testing.T) {
+			result := ArgExists(tc.args, tc.prefix)
+			if result != tc.expected {
+				t.Errorf("got %t, want %t", result, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Updates defaults according to vpa benchmarking spike/new documentation defaults.

I was thinking of not setting CPU limits for the operator, but since we [_should ideally_](https://sdk.operatorframework.io/docs/best-practices/managing-resources/#managing-resources) set memory limits at least, I added additional CPU limits to the main container (alongisde the kube-rbac-proxy container limits), in case something _really_ goes wrong somehow, we do not use more CPU than intended (and all the operator is doing is reconciling anyways).