### PR TITLE
Remove replaces from manifest

### DIFF
--- a/bundle/manifests/vertical-pod-autoscaler.clusterserviceversion.yaml
+++ b/bundle/manifests/vertical-pod-autoscaler.clusterserviceversion.yaml
@@ -787,5 +787,4 @@ spec:
   minKubeVersion: 1.11.0
   provider:
     name: Red Hat
-  replaces: verticalpodautoscaler.v4.17.0
   version: 4.18.0


### PR DESCRIPTION
OCP puts in `skips`. There is no need for `replaces`, and this make a release pipeline hurt, see e.g. https://iib.engineering.redhat.com/api/v1/builds/874123/logs