### PR TITLE
PODAUTO-284: Add CI checks to ensure "make bundle/generate" before pushing 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,12 @@ test-scorecard: operator-sdk ## Run the scorecard tests. Requires an OpenShift c
 	$(OPERATOR_SDK) scorecard bundle -n default -w 300s
 
 .PHONY: check
-check: fmt vet manifest-diff lint test ## Check code for formatting, vet, lint, manifest-diff and run tests.
+check: manifest-diff lint yamllint test ## Run quick checks for a dev before pushing code.
+
+.PHONY: ensure-commands-are-noops ## Ensure that make generate and bundle are no-ops.
+ensure-commands-are-noops: generate bundle
+	@git diff -s --exit-code api/v1/zz_generated.*.go || (echo "Build failed: a model has been changed but the generated resources aren't up to date. Run 'make generate' and update your PR." && exit 1)
+	@git diff -s --exit-code -I "createdAt" bundle config || (echo "Build failed: the bundle, config files has been changed but the generated bundle, config files aren't up to date. Run 'make bundle' and update your PR." && git -P diff -I "createdAt" bundle config && exit 1)
 
 ##@ E2E Tests
 


### PR DESCRIPTION
Add ensure-commands-are-noops ci check such that we make sure that a dev has run make bundle and make generate before pushing their changes.

~Also removes gofmt and govet make targets since golangci-lint already has rules that do the same thing~, and fixes up `make check` such that it includes all commands that devs can and should use before pushing.