### PR TITLE
OCPBUGS-45521: Remove unnecessary initialization-resource CSV annotation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,7 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 
 # Requires BUNDLE_IMG to be set to the bundle image to be used.
 .PHONY: deploy-bundle
-deploy-bundle: operator-sdk undeploy-bundle create-ns ## Deploy the controller in the bundle format with OLM.
+deploy-bundle: operator-sdk undeploy-bundle delete-ns create-ns ## Deploy the controller in the bundle format with OLM.
 	$(OPERATOR_SDK) run bundle $(BUNDLE_IMG) --namespace $(DEPLOY_NAMESPACE) --security-context-config restricted --timeout 5m
 
 .PHONY: undeploy-bundle
@@ -450,7 +450,7 @@ full-olm-deploy: build docker-build docker-push bundle bundle-build bundle-push 
 
 # Requires CATALOG_IMG to be set to the catalog image to be used.
 .PHONY: deploy-catalog
-deploy-catalog: create-ns ## Deploy the CatalogSource and OperatorGroup, along with the Operator Subscription.
+deploy-catalog: delete-ns create-ns ## Deploy the CatalogSource and OperatorGroup, along with the Operator Subscription.
 	rm -rf $(OLM_OUTPUT_DIR)
 	mkdir -p $(OLM_OUTPUT_DIR)
 	cp -r $(OLM_MANIFESTS_DIR)/* $(OLM_OUTPUT_DIR)

--- a/bundle/manifests/vertical-pod-autoscaler.clusterserviceversion.yaml
+++ b/bundle/manifests/vertical-pod-autoscaler.clusterserviceversion.yaml
@@ -55,7 +55,7 @@ metadata:
     categories: OpenShift Optional
     certifiedLevel: Primed
     containerImage: quay.io/openshift/origin-vertical-pod-autoscaler-operator:4.18.0
-    createdAt: "2024-12-04T01:11:16Z"
+    createdAt: "2024-12-05T23:41:17Z"
     description: An operator to run the OpenShift Vertical Pod Autoscaler. Vertical
       Pod Autoscaler (VPA) can be configured to monitor a workload's resource utilization,
       and then adjust its CPU and memory limits by updating the pod (future) or restarting
@@ -72,22 +72,6 @@ metadata:
     features.operators.openshift.io/token-auth-gcp: "false"
     healthIndex: B
     olm.skipRange: '>=4.5.0 <4.18.0'
-    operatorframework.io/initialization-resource: |-
-      {
-        "apiVersion": "autoscaling.openshift.io/v1",
-        "kind": "VerticalPodAutoscalerController",
-        "metadata": {
-          "name": "default",
-          "namespace": "openshift-vertical-pod-autoscaler"
-        },
-        "spec": {
-          "podMinCPUMillicores": 25,
-          "podMinMemoryMb": 250,
-          "recommendationOnly": false,
-          "safetyMarginFraction": 0.15,
-          "minReplicas": 2
-        }
-      }
     operatorframework.io/suggested-namespace: openshift-vertical-pod-autoscaler
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/config/manifests/bases/vertical-pod-autoscaler.clusterserviceversion.yaml
+++ b/config/manifests/bases/vertical-pod-autoscaler.clusterserviceversion.yaml
@@ -24,22 +24,6 @@ metadata:
     features.operators.openshift.io/token-auth-gcp: "false"
     healthIndex: B
     olm.skipRange: '>=4.5.0 <4.18.0'
-    operatorframework.io/initialization-resource: |-
-      {
-        "apiVersion": "autoscaling.openshift.io/v1",
-        "kind": "VerticalPodAutoscalerController",
-        "metadata": {
-          "name": "default",
-          "namespace": "openshift-vertical-pod-autoscaler"
-        },
-        "spec": {
-          "podMinCPUMillicores": 25,
-          "podMinMemoryMb": 250,
-          "recommendationOnly": false,
-          "safetyMarginFraction": 0.15,
-          "minReplicas": 2
-        }
-      }
     operatorframework.io/suggested-namespace: openshift-vertical-pod-autoscaler
     operators.operatorframework.io/builder: operator-sdk-v1.35.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/config/olm-catalog/vpa-subscription.yaml
+++ b/config/olm-catalog/vpa-subscription.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   channel: stable
   installPlanApproval: Automatic
-  name: vertical-pod-autoscaler-operator
+  name: vertical-pod-autoscaler
   source: vpa-catalog
   sourceNamespace: OPERATOR_NAMESPACE_PLACEHOLDER


### PR DESCRIPTION
Removes the annotation because the operator code itself initializes a VPA controller object during startup.

Also fix incorrect package name in local catalogsource manifest and make sure namespace is regenerated before deploying during local testing.