### PR TITLE
Clean old bundles before regenerating

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -377,6 +377,8 @@ endif
 .PHONY: bundle
 bundle: manifests kustomize predeploy operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
 	$(OPERATOR_SDK) generate kustomize manifests
+	# Remove old bundle dir in case there were files in the old collection that wouldn't be in the new
+	rm -rf $(BUNDLE_MANIFESTS_DIR)
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
 	$(OPERATOR_SDK) bundle validate ./bundle
 


### PR DESCRIPTION
This is a follow-up to #197

Un-owned files from previous versions were being left around in the bundle without manually removing the bundle/manifests dir prior to regenerating.