### PR TITLE
OCPBUGS-57966: Updates for 4.20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Must be semver compliant
-export OPERATOR_VERSION ?= 4.19.0
+export OPERATOR_VERSION ?= 4.20.0
 OPERATOR_PKG_NAME ?= vertical-pod-autoscaler
 IMAGE_VERSION ?= $(OPERATOR_VERSION)
 BUNDLE_VERSION ?= $(IMAGE_VERSION)
@@ -445,8 +445,8 @@ catalog-push: ## Push a catalog image.
 ## Optionally, the easiest way to pass IMG arguments is to instead set the following environment variables:
 ## - IMAGE_TAG_BASE: The base image tag for the operator.
 ## - OPERATOR_VERSION: The version of the operator.
-## e.g. make e2e-olm-local IMAGE_TAG_BASE=quay.io/$(USER)/vertical-pod-autoscaler-operator OPERATOR_VERSION=4.19.0 KUBECONFIG=/path/to/kubeconfig
-## This will create OPERATOR_IMG=quay.io/$(IMAGE_TAG_BASE}:4.19.0, BUNDLE_IMG=quay.io/${IMAGE_TAG_BASE}-bundle:4.19.0, and CATALOG_IMG=quay.io/${IMAGE_TAG_BASE}-catalog:4.19.0
+## e.g. make e2e-olm-local IMAGE_TAG_BASE=quay.io/$(USER)/vertical-pod-autoscaler-operator OPERATOR_VERSION=4.20.0 KUBECONFIG=/path/to/kubeconfig
+## This will create OPERATOR_IMG=quay.io/$(IMAGE_TAG_BASE}:4.20.0, BUNDLE_IMG=quay.io/${IMAGE_TAG_BASE}-bundle:4.20.0, and CATALOG_IMG=quay.io/${IMAGE_TAG_BASE}-catalog:4.20.0
 .PHONY: full-olm-deploy
 full-olm-deploy: build docker-build docker-push bundle bundle-build bundle-push catalog-build catalog-push deploy-catalog ## Fully deploy the catalog source that contains the operator. Builds and pushes the operator, bundle, and catalog images. Undeploy with 'make undeploy-catalog'.
 

--- a/bundle/image-references
+++ b/bundle/image-references
@@ -6,7 +6,7 @@ spec:
   - name: vertical-pod-autoscaler-rhel8-operator
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-vertical-pod-autoscaler-operator:4.19.0
+      name: quay.io/openshift/origin-vertical-pod-autoscaler-operator:4.20.0
   - name: vertical-pod-autoscaler-rhel8
     from:
       kind: DockerImage

--- a/bundle/manifests/vertical-pod-autoscaler.clusterserviceversion.yaml
+++ b/bundle/manifests/vertical-pod-autoscaler.clusterserviceversion.yaml
@@ -54,8 +54,8 @@ metadata:
     capabilities: Full Lifecycle
     categories: OpenShift Optional
     certifiedLevel: Primed
-    containerImage: quay.io/openshift/origin-vertical-pod-autoscaler-operator:4.19.0
-    createdAt: "2025-01-08T21:49:53Z"
+    containerImage: quay.io/openshift/origin-vertical-pod-autoscaler-operator:4.20.0
+    createdAt: "2025-06-17T22:15:20Z"
     description: An operator to run the OpenShift Vertical Pod Autoscaler. Vertical
       Pod Autoscaler (VPA) can be configured to monitor a workload's resource utilization,
       and then adjust its CPU and memory limits by updating the pod (future) or restarting
@@ -71,7 +71,7 @@ metadata:
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
     healthIndex: B
-    olm.skipRange: '>=4.5.0 <4.19.0'
+    olm.skipRange: '>=4.5.0 <4.20.0'
     operatorframework.io/suggested-namespace: openshift-vertical-pod-autoscaler
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -82,7 +82,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: vertical-pod-autoscaler.v4.19.0
+  name: vertical-pod-autoscaler.v4.20.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -649,7 +649,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/openshift/origin-vertical-pod-autoscaler-operator:4.19.0
+                image: quay.io/openshift/origin-vertical-pod-autoscaler-operator:4.20.0
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:
@@ -789,7 +789,7 @@ spec:
   - scaling
   labels:
     olm-owner-enterprise-app: vertical-pod-autoscaler-operator
-    olm-status-descriptors: vertical-pod-autoscaler-operator.v4.19.0
+    olm-status-descriptors: vertical-pod-autoscaler-operator.v4.20.0
   links:
   - name: Vertical Pod Autoscaler Documentation
     url: https://docs.openshift.com/container-platform/latest/nodes/pods/nodes-pods-vertical-autoscaler.html
@@ -800,4 +800,4 @@ spec:
   minKubeVersion: 1.11.0
   provider:
     name: Red Hat
-  version: 4.19.0
+  version: 4.20.0

--- a/bundle/vertical-pod-autoscaler-operator.package.yaml
+++ b/bundle/vertical-pod-autoscaler-operator.package.yaml
@@ -2,5 +2,5 @@
 packageName: vertical-pod-autoscaler
 channels:
 - name: stable
-  currentCSV: vertical-pod-autoscaler.v4.19.0
+  currentCSV: vertical-pod-autoscaler.v4.20.0
 defaultChannel: stable

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 images:
 - name: quay.io/openshift/origin-vertical-pod-autoscaler-operator
   newName: quay.io/openshift/origin-vertical-pod-autoscaler-operator
-  newTag: 4.19.0
+  newTag: 4.20.0
 resources:
 - manager.yaml
 patches:

--- a/config/manifests/bases/vertical-pod-autoscaler.clusterserviceversion.yaml
+++ b/config/manifests/bases/vertical-pod-autoscaler.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: OpenShift Optional
     certifiedLevel: Primed
-    containerImage: quay.io/openshift/origin-vertical-pod-autoscaler-operator:4.19.0
+    containerImage: quay.io/openshift/origin-vertical-pod-autoscaler-operator:4.20.0
     createdAt: "2024-07-30T19:27:53Z"
     description: An operator to run the OpenShift Vertical Pod Autoscaler. Vertical
       Pod Autoscaler (VPA) can be configured to monitor a workload's resource utilization,
@@ -23,7 +23,7 @@ metadata:
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
     healthIndex: B
-    olm.skipRange: '>=4.5.0 <4.19.0'
+    olm.skipRange: '>=4.5.0 <4.20.0'
     operatorframework.io/suggested-namespace: openshift-vertical-pod-autoscaler
     operators.operatorframework.io/builder: operator-sdk-v1.35.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -34,7 +34,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: vertical-pod-autoscaler.v4.19.0
+  name: vertical-pod-autoscaler.v4.20.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -190,7 +190,7 @@ spec:
   - scaling
   labels:
     olm-owner-enterprise-app: vertical-pod-autoscaler-operator
-    olm-status-descriptors: vertical-pod-autoscaler-operator.v4.19.0
+    olm-status-descriptors: vertical-pod-autoscaler-operator.v4.20.0
   links:
   - name: Vertical Pod Autoscaler Documentation
     url: https://docs.openshift.com/container-platform/latest/nodes/pods/nodes-pods-vertical-autoscaler.html

--- a/config/olm-catalog/vpa-catalogsource.yaml
+++ b/config/olm-catalog/vpa-catalogsource.yaml
@@ -8,7 +8,7 @@ spec:
   sourceType: grpc
   grpcPodConfig:
     securityContextConfig: restricted
-  image: quay.io/openshift/origin-vertical-pod-autoscaler-operator-catalog:4.19.0
+  image: quay.io/openshift/origin-vertical-pod-autoscaler-operator-catalog:4.20.0
   updateStrategy:
     registryPoll:
       interval: 10m

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -72,7 +72,7 @@ function await_for_controllers() {
 # if it exists but is not a git repo, exit
 # if it does not exist, clone the repo into a temporary directory
 AUTOSCALER_PKG="github.com/openshift/kubernetes-autoscaler"
-RELEASE_VERSION="release-4.19"
+RELEASE_VERSION="release-4.20"
 
 # check if cached repo exists
 if [ -d "${AUTOSCALER_TMP:-}" ]; then

--- a/hack/manifest-diff-upstream.sh
+++ b/hack/manifest-diff-upstream.sh
@@ -6,7 +6,7 @@
 # can likewise be updated so that the VPA code and manifests stay in sync.
 
 # Requires: hack/yamls2list.sed, hack/filter-upstream-rbac.jq, bin/json2yaml, bin/yaml2json
-operand_branch="release-4.19"
+operand_branch="release-4.20"
 repo_base="$( dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )")"
 repo_name=$(basename "${repo_base}")
 upstream_manifest_url_prefix="https://raw.githubusercontent.com/openshift/kubernetes-autoscaler/$operand_branch/vertical-pod-autoscaler/deploy"


### PR DESCRIPTION
```
sed -i 's/4.19/4.20/g' $(git grep -l 4.19 config/) hack/manifest-diff-upstream.sh hack/e2e.sh Makefile bundle/image-references bundle/vertical-pod-autoscaler-operator.package.yaml
```

This commit updates references in the repo from 4.19 to 4.20, except for actually bumping go dependencies. We need this to satisfy ART builds, but we cannot do a full update for our OpenShift 4.20 dependencices yet due to the k8s 1.33 rebase not being finished, so we will hold off on golang dep bumps, go1.24 bumps, and image bumps until then.

We will have a separate PR for that once the rebase resolves.