### PR TITLE
OCPBUGS-60059: Fix version injection regression

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,14 +17,17 @@ RUN go mod verify
 COPY cmd/main.go cmd/main.go
 COPY api/ api/
 COPY internal/ internal/
-
+# Copy the Makefile so we don't have to duplicate the build logic in the containerfile
+COPY Makefile Makefile
+# Our Makefile uses the git hash to inject the version into the binary
+COPY .git .git
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -mod=vendor -a -o manager cmd/main.go
+RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} make container-binary-build
 
 FROM registry.ci.openshift.org/ocp/4.21:base-rhel9
 WORKDIR /

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -21,6 +21,10 @@ COPY vendor vendor/
 COPY cmd/main.go cmd/main.go
 COPY api/ api/
 COPY internal/ internal/
+# Copy the Makefile so we don't have to duplicate the build logic in the containerfile
+COPY Makefile Makefile
+# Our Makefile uses the git hash to inject the version into the binary
+COPY .git .git
 
 
 # Build
@@ -28,7 +32,7 @@ COPY internal/ internal/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -mod=vendor -a -o manager cmd/main.go
+RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} make container-binary-build
 
 FROM registry.ci.openshift.org/ocp/4.21:base-rhel9
 WORKDIR /

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,12 @@ BUNDLE_VERSION ?= $(IMAGE_VERSION)
 BUNDLE_MANIFESTS_DIR ?= $(shell pwd)/bundle/manifests
 OLM_MANIFESTS_DIR ?= $(shell pwd)/config/olm-catalog
 
+# We used to inject the git hash for version before https://github.com/openshift/vertical-pod-autoscaler-operator/pull/169, accidentally
+# removed it. This is for parity with the old behavior, should give us e.g. "v4.21.0-2332559":
+INJECT_VERSION     ?= v${OPERATOR_VERSION}-$(shell git rev-parse --short=7 HEAD)
+# version used to be in pkg, but now it's internal 
+LD_FLAGS    ?= -X github.com/openshift/vertical-pod-autoscaler-operator/internal/version.Raw=$(INJECT_VERSION)
+
 OUTPUT_DIR := ./_output
 OLM_OUTPUT_DIR := $(OUTPUT_DIR)/olm-catalog
 
@@ -190,11 +196,15 @@ e2e-olm-local: full-olm-deploy test-e2e
 
 .PHONY: build
 build: manifests generate fmt vet ## Build manager binary.
-	go build -o bin/manager cmd/main.go
+	go build -ldflags "$(LD_FLAGS)" -o bin/manager cmd/main.go
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./cmd/main.go
+
+.PHONY: container-binary-build
+container-binary-build: ## Build the manager binary for Docker (with out manifest/fmt/vet/etc)
+	go build -mod=vendor -a -ldflags "$(LD_FLAGS)" -o manager cmd/main.go
 
 # If you wish to build the manager image targeting other platforms you can use the --platform flag.
 # (i.e. docker build --platform linux/arm64). However, you must enable docker buildKit for it.

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -136,7 +136,7 @@ function wait_for_controllers() {
   updater_expected=$(expected_replicas "vpa-updater-default")
 
   echo "Waiting for VPA controllers to be ready..."
-  
+
   while [ "${retries}" -ge 0 ]; do
     local recommender
     local admission
@@ -147,19 +147,19 @@ function wait_for_controllers() {
     recommender=${recommender:-0}
     admission=${admission:-0}
     updater=${updater:-0}
-    
+
     local ready=true
 
     # Check each controller against expected replica count
     [ "${recommender}" -ge "${recommender_expected}" ] || ready=false
     [ "${admission}" -ge "${admission_expected}" ] || ready=false
     [ "${updater}" -ge "${updater_expected}" ] || ready=false
-    
+
     if [ "${ready}" == "true" ]; then
       echo "All required VPA controllers are ready"
       return 0
     fi
-    
+
     retries=$((retries - 1))
     [ ${retries} -ge 0 ] && echo "${retries} retries left"
     sleep 5
@@ -168,6 +168,56 @@ function wait_for_controllers() {
   echo "Current replicas: recommender=${recommender}, admission=${admission}, updater=${updater}"
   echo "Expected replicas: recommender=${recommender_expected}, admission=${admission_expected}, updater=${updater_expected}"
   return 1
+}
+
+function verify_operator_version() {
+  echo "Verifying operator version is properly set..."
+
+  local operator_logs
+  operator_logs=$(${KUBECTL} logs -n "${namespace}" --selector k8s-app=vertical-pod-autoscaler-operator --tail=100)
+
+  # Extract the version line from logs
+  local version_line
+  version_line=$(echo "${operator_logs}" | grep -E "Version.*version.*vertical-pod-autoscaler-operator" | head -1)
+
+  if [ -z "${version_line}" ]; then
+    echo "ERROR: Could not find version information in operator logs"
+    echo ""
+    echo "=== Operator Logs ==="
+    echo "${operator_logs}"
+    return 1
+  fi
+
+  echo "Found version line: ${version_line}"
+
+  # Extract the actual version string (e.g., "v4.21.0-abc1234")
+  local version_string
+  version_string=$(echo "${version_line}" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+[-a-zA-Z0-9]*' | head -1)
+
+  if [ -z "${version_string}" ]; then
+    echo "ERROR: Could not extract version string from logs"
+    echo "Version line was: ${version_line}"
+    return 1
+  fi
+
+  echo "Extracted version: ${version_string}"
+
+  # Verify it's not the default "was-not-built-properly" value
+  if echo "${version_string}" | grep -q "was-not-built-properly"; then
+    echo "ERROR: Operator version was not properly injected during build"
+    echo "Got: ${version_string}"
+    return 1
+  fi
+
+  # Verify it's a valid semver format (starts with v and has major.minor.patch)
+  if ! echo "${version_string}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+'; then
+    echo "ERROR: Operator version is not in valid semver format"
+    echo "Got: ${version_string}"
+    return 1
+  fi
+
+  echo "Operator version is valid: ${version_string}"
+  return 0
 }
 
 # Setup autoscaler repository
@@ -198,6 +248,18 @@ SCRIPT_ROOT="${GOPATH}/autoscaler/vertical-pod-autoscaler"
 
 echo "Using GOPATH: ${GOPATH}"
 echo "Using SCRIPT_ROOT: ${SCRIPT_ROOT}"
+
+# Verify the operator version is properly set
+echo ""
+echo "================================"
+echo "Verifying Operator Version"
+echo "================================"
+
+if ! verify_operator_version; then
+  echo ""
+  echo "ERROR: Operator version verification failed"
+  exit 1
+fi
 
 # Verify VPA controllers are running
 echo ""


### PR DESCRIPTION
We broke version injection with #169, this just re-adds version injection so we stop getting the "improperly built" version errors. 

It does this by: 
- Adding some version injection vars in the Makefile 
- Copying the Makefile and .git directory into the docker build stages so the version can be retrieved (we used to include the git hash of the build in our version before we broke it) 
- Adding a simple binary build target in the Makefile and calling it from the dockerfile 
- I don't think I broke multi-arch

**NOTE:** We used to copy everything `COPY . . ` so we can go back to that if that's just easier, but I was assuming we found value in explicitly listing just the things in the Dockerfile that the build needs to live?

Now we get: 
```
jkyros@jkyros-thinkpadp16vgen1:~/dev/vertical-pod-autoscaler-operator$ podman run  localhost/vpa:latest
2025-10-01T22:54:55Z    INFO    setup   Go Version      {"version": "go1.23.9 (Red Hat 1.23.9-1.el9_6)"}
2025-10-01T22:54:55Z    INFO    setup   Go OS/Arch      {"os": "linux", "arch": "amd64"}
2025-10-01T22:54:55Z    INFO    setup   Version {"version": "vertical-pod-autoscaler-operator v4.20.0-fcb0d8f"}
```