### PR TITLE
AUTOSCALE-433: Fixup e2e.sh hack script more

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -57,10 +57,11 @@ function run_upstream_vpa_tests() {
   echo "Running ${SUITE} e2e tests from upstream..."
   pushd "${SCRIPT_ROOT}/e2e" > /dev/null
   
-  GO111MODULE=on go test -mod vendor ./v1/*go -v \
-    --test.timeout=120m \
+  VPA_NAMESPACE="${namespace}" GO111MODULE=on go test -mod vendor ./v1/*go -v \
+    --test.timeout=125m \
     --args \
     --ginkgo.v=true \
+    --ginkgo.timeout=2h \
     --ginkgo.focus="\[VPA\] \[${SUITE}\]" \
     --report-dir="${REPORT_DIR}/vpa_artifacts" \
     --disable-log-dump \


### PR DESCRIPTION
The PR has two parts:

* The default ginkgo timeout is 1 hour. I am overriding it to 2 hours in the e2e hack script.
* I also extend the regular go test timeout to 125 minutes so that if by whatever reason somehow the ginkgo timeout doesn't happen at 2 hours, the go test timeout will still panic and stop the test eventually.
* Apply VPA_NAMESPACE env variable to script for custom namespace for tests