### PR TITLE
AUTOSCALE-67: VPA: Reduce potentially unsafe/uneeded privileges deployed by vpa operator

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -4,31 +4,7 @@ kind: ClusterRole
 metadata:
   name: vertical-pod-autoscaler-operator
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - events
-  - pods
-  - secrets
-  - services
-  verbs:
-  - '*'
-- apiGroups:
-  - apps
-  resources:
-  - daemonsets
-  - deployments
-  - replicasets
-  - statefulsets
-  verbs:
-  - '*'
-- apiGroups:
-  - autoscaling.openshift.io
-  resources:
-  - '*'
-  verbs:
-  - '*'
+# VerticalPodAutoscalerController CRD management
 - apiGroups:
   - autoscaling.openshift.io
   resources:
@@ -55,6 +31,55 @@ rules:
   - get
   - patch
   - update
+
+# Deployment management (operator creates VPA component deployments)
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+
+# Service management (webhook service)
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+
+# ConfigMap management (CA cert configmap)
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+
+# Event recording
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+
+# NetworkPolicy management
 - apiGroups:
   - networking.k8s.io
   resources:
@@ -62,6 +87,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - list
   - patch
   - update


### PR DESCRIPTION
## Summary

- Replace broad wildcard permissions with specific, granular RBAC rules
- Follow principle of least privilege for better security
- Organize permissions by purpose with clear comments for maintainability

## Changes

- **VerticalPodAutoscalerController CRD management**: Specific verbs instead of wildcards
- **Deployment management**: Explicit permissions for VPA component deployments
- **Service management**: Targeted permissions for webhook service
- **ConfigMap management**: Scoped permissions for CA cert configmap
- **Event recording**: Limited to create and patch
- **NetworkPolicy management**: Added missing `get` verb

## Test plan

- [ ] Verify operator can manage VerticalPodAutoscalerController resources
- [ ] Confirm operator can create and manage VPA component deployments
- [ ] Test webhook service creation and updates
- [ ] Validate ConfigMap operations for CA certificates
- [ ] Check event recording functionality
- [ ] Verify NetworkPolicy management

🤖 Generated with [Claude Code](https://claude.com/claude-code)