### PR TITLE
NO-JIRA: fix: sync operator RBAC from kubebuilder markers

### DIFF
--- a/bundle/manifests/vertical-pod-autoscaler.clusterserviceversion.yaml
+++ b/bundle/manifests/vertical-pod-autoscaler.clusterserviceversion.yaml
@@ -228,12 +228,12 @@ spec:
           - configmaps
           - services
           verbs:
+          - create
           - get
           - list
-          - watch
-          - create
-          - update
           - patch
+          - update
+          - watch
         - apiGroups:
           - ""
           resources:
@@ -246,12 +246,12 @@ spec:
           resources:
           - deployments
           verbs:
+          - create
           - get
           - list
-          - watch
-          - create
-          - update
           - patch
+          - update
+          - watch
         - apiGroups:
           - autoscaling.openshift.io
           resources:
@@ -281,9 +281,28 @@ spec:
         - apiGroups:
           - config.openshift.io
           resources:
+          - apiservers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - config.openshift.io
+          resources:
           - infrastructures
           verbs:
           - get
+        - apiGroups:
+          - events.k8s.io
+          resources:
+          - events
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
         - apiGroups:
           - networking.k8s.io
           resources:
@@ -295,14 +314,6 @@ spec:
           - list
           - patch
           - update
-          - watch
-        - apiGroups:
-          - config.openshift.io
-          resources:
-          - apiservers
-          verbs:
-          - get
-          - list
           - watch
         - apiGroups:
           - authentication.k8s.io

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -10,12 +10,12 @@ rules:
   - configmaps
   - services
   verbs:
+  - create
   - get
   - list
-  - watch
-  - create
-  - update
   - patch
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:
@@ -28,12 +28,12 @@ rules:
   resources:
   - deployments
   verbs:
+  - create
   - get
   - list
-  - watch
-  - create
-  - update
   - patch
+  - update
+  - watch
 - apiGroups:
   - autoscaling.openshift.io
   resources:
@@ -63,9 +63,28 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - apiservers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
   - infrastructures
   verbs:
   - get
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:
@@ -77,12 +96,4 @@ rules:
   - list
   - patch
   - update
-  - watch
-- apiGroups:
-  - config.openshift.io
-  resources:
-  - apiservers
-  verbs:
-  - get
-  - list
   - watch

--- a/internal/controller/verticalpodautoscaler/verticalpodautoscaler_controller.go
+++ b/internal/controller/verticalpodautoscaler/verticalpodautoscaler_controller.go
@@ -191,9 +191,12 @@ type VerticalPodAutoscalerControllerReconciler struct {
 // +kubebuilder:rbac:groups=autoscaling.openshift.io,resources=verticalpodautoscalercontrollers/finalizers,verbs=update
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch;get;list;watch;update
 // +kubebuilder:rbac:groups="",resources=configmaps;services,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get;list;watch
+// +kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures,verbs=get
+
 func (r *VerticalPodAutoscalerControllerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	reqLogger := r.Log.WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name)
 	reqLogger.Info("Reconciling VerticalPodAutoscalerController")


### PR DESCRIPTION
`controller-gen` skipped markers immediately above Reconcile ([controller-tools#551](https://github.com/kubernetes-sigs/controller-tools/issues/551)).

Add the required blank line, events.k8s.io and infrastructure permissions, and regenerate config/rbac and bundle clusterPermissions.