### PR TITLE
AUTOSCALE-813: Remove master node selector

### DIFF
--- a/bundle/manifests/vertical-pod-autoscaler.clusterserviceversion.yaml
+++ b/bundle/manifests/vertical-pod-autoscaler.clusterserviceversion.yaml
@@ -749,7 +749,6 @@ spec:
                   readOnly: true
               nodeSelector:
                 kubernetes.io/os: linux
-                node-role.kubernetes.io/master: ""
               priorityClassName: system-node-critical
               restartPolicy: Always
               securityContext:
@@ -759,6 +758,9 @@ spec:
               tolerations:
               - effect: NoSchedule
                 key: node-role.kubernetes.io/master
+                operator: Exists
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/control-plane
                 operator: Exists
               volumes:
               - name: vpa-operator-metrics-tls-certs

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -89,7 +89,6 @@ spec:
           mountPath: /etc/metrics-tls-certs
       terminationGracePeriodSeconds: 10
       nodeSelector:
-        node-role.kubernetes.io/master: ""
         kubernetes.io/os: linux
       restartPolicy: Always
       securityContext:
@@ -98,6 +97,9 @@ spec:
       - key: "node-role.kubernetes.io/master"
         operator: "Exists"
         effect: "NoSchedule"
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists
       volumes:
       - name: vpa-operator-metrics-tls-certs
         secret:

--- a/internal/controller/verticalpodautoscaler/verticalpodautoscaler_controller.go
+++ b/internal/controller/verticalpodautoscaler/verticalpodautoscaler_controller.go
@@ -829,8 +829,8 @@ func (r *VerticalPodAutoscalerControllerReconciler) getDefaultNodeSelector() map
 	}
 	// For standard clusters, schedule on master nodes
 	return map[string]string{
-		"node-role.kubernetes.io/master": "",
-		"kubernetes.io/os":               "linux",
+		"node-role.kubernetes.io/control-plane": "",
+		"kubernetes.io/os":                      "linux",
 	}
 }
 
@@ -848,6 +848,11 @@ func (r *VerticalPodAutoscalerControllerReconciler) getDefaultTolerations() []co
 		// For standard clusters, add master node toleration
 		tolerations = append(tolerations, corev1.Toleration{
 			Key:      "node-role.kubernetes.io/master",
+			Effect:   corev1.TaintEffectNoSchedule,
+			Operator: corev1.TolerationOpExists,
+		})
+		tolerations = append(tolerations, corev1.Toleration{
+			Key:      "node-role.kubernetes.io/control-plane",
 			Effect:   corev1.TaintEffectNoSchedule,
 			Operator: corev1.TolerationOpExists,
 		})

--- a/internal/controller/verticalpodautoscaler/verticalpodautoscaler_controller_test.go
+++ b/internal/controller/verticalpodautoscaler/verticalpodautoscaler_controller_test.go
@@ -463,8 +463,8 @@ func TestVPAPodSpecNodeSelector(t *testing.T) {
 			name:                   "standard cluster - master node selector",
 			isExternalControlPlane: false,
 			expectedNodeSelector: map[string]string{
-				"node-role.kubernetes.io/master": "",
-				"kubernetes.io/os":               "linux",
+				"node-role.kubernetes.io/control-plane": "",
+				"kubernetes.io/os":                      "linux",
 			},
 		},
 		{
@@ -537,13 +537,18 @@ func TestVPAPodSpecTolerations(t *testing.T) {
 			spec := r.VPAPodSpec(vpa, controllerParams[0])
 
 			hasMasterToleration := false
+			hasControlPlaneToleration := false
 			for _, tol := range spec.Tolerations {
+				// TODO: at some point the master taint will be removed. When
+				// it is, simplify this down to just check for control-plane
 				if tol.Key == "node-role.kubernetes.io/master" {
 					hasMasterToleration = true
-					break
+				} else if tol.Key == "node-role.kubernetes.io/control-plane" {
+					hasControlPlaneToleration = true
 				}
 			}
 			assert.Equal(t, tc.expectMasterToleration, hasMasterToleration)
+			assert.Equal(t, tc.expectMasterToleration, hasControlPlaneToleration)
 
 			// Always should have CriticalAddonsOnly toleration
 			hasCriticalToleration := false


### PR DESCRIPTION
Also, switch node selector from master to control-plane for node selector in advance of removal of deprecated master label.  (see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.20.md#urgent-upgrade-notes)

Tolerate both taints so that we can continue to use whichever taint is present.