### PR TITLE
Add APIServer config CRD for CI tests

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -19,5 +19,6 @@ ignore:
 - config/vpa/vpa-crd.yaml
 - config/vpa/vpa-rbac.yaml
 - config/vpa/vpacheckpoint-crd.yaml
+- test/testdata/crd/
 
 # we need to ignore vpa yamls because manifest-diff-upstream copies it directly from the upstream repo and expects no git diff

--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,10 @@ manifest-diff: build-testutil ## Compare permissions and CRDs from upstream mani
 yamllint: ## Run yamllint against manifests.
 	hack/yaml-lint.sh
 
+.PHONY: fetch-test-crds
+fetch-test-crds: yq ## Download OpenShift CRDs needed for envtest.
+	hack/fetch-test-crds.sh
+
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path --use-deprecated-gcs=false)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out

--- a/hack/fetch-test-crds.sh
+++ b/hack/fetch-test-crds.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Downloads OpenShift CRDs needed for envtest from the openshift/api repository.
+# The commit is derived from the github.com/openshift/api version in go.mod.
+#
+# The downloaded CRDs have x-kubernetes-validations stripped because envtest's
+# kubebuilder API server may not support the latest CEL validation functions.
+#
+# Usage: hack/fetch-test-crds.sh
+#
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+output_dir="${repo_root}/test/testdata/crd"
+yq="${repo_root}/bin/yq"
+
+if [[ ! -x "${yq}" ]]; then
+  echo "ERROR: yq not found at ${yq}; run 'make yq' first" >&2
+  exit 1
+fi
+
+# Extract the commit hash from the openshift/api pseudo-version in go.mod.
+# Pseudo-versions look like: v0.0.0-20260610004746-5ce2c3071851
+openshift_api_version=$(go list -m -f '{{.Version}}' github.com/openshift/api)
+commit=$(echo "${openshift_api_version}" | sed -E 's/.*-([0-9a-f]{12,})$/\1/')
+
+if [[ -z "${commit}" ]]; then
+  echo "ERROR: could not extract commit hash from openshift/api version: ${openshift_api_version}" >&2
+  exit 1
+fi
+
+echo "Using openshift/api commit: ${commit}"
+
+# CRDs to download, as paths relative to the openshift/api repo root.
+# We use the TechPreviewNoUpgrade variant to include fields behind feature gates
+# (e.g. TLSAdherence) that tests need to exercise.
+crds=(
+  "config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_apiservers-TechPreviewNoUpgrade.crd.yaml"
+)
+
+mkdir -p "${output_dir}"
+
+for crd_path in "${crds[@]}"; do
+  filename=$(basename "${crd_path}")
+  url="https://raw.githubusercontent.com/openshift/api/${commit}/${crd_path}"
+  echo "Downloading ${filename} ..."
+  curl -sfL "${url}" \
+    | "${yq}" --indent 2 'del(.. | .x-kubernetes-validations?)' \
+    > "${output_dir}/${filename}"
+done
+
+echo "CRDs saved to ${output_dir}"

--- a/internal/controller/verticalpodautoscaler/suite_test.go
+++ b/internal/controller/verticalpodautoscaler/suite_test.go
@@ -89,7 +89,10 @@ var _ = AfterSuite(func() {
 
 func StartEnvTest() (*rest.Config, *envtest.Environment, error) {
 	testEnv := &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "..", "config", "crd", "bases"),
+			filepath.Join("..", "..", "..", "test", "testdata", "crd"),
+		},
 		ErrorIfCRDPathMissing: true,
 	}
 

--- a/internal/controller/verticalpodautoscaler/verticalpodautoscaler_controller_envtest_test.go
+++ b/internal/controller/verticalpodautoscaler/verticalpodautoscaler_controller_envtest_test.go
@@ -173,8 +173,10 @@ var _ = Describe("VerticalPodAutoscalerController Controller", Ordered, func() {
 			}
 			Expect(k8sClient.Create(testCtx, vpaController)).To(Succeed())
 
-			// Check that controller exists and save resource version
-			Expect(k8sClient.Get(testCtx, vpaControllerNN, vpaController)).To(Succeed())
+			// Wait for the cache to observe the newly created controller
+			Eventually(func() error {
+				return k8sClient.Get(testCtx, vpaControllerNN, vpaController)
+			}, timeout, interval).Should(Succeed())
 			originalResourceVersion := vpaController.ResourceVersion
 
 			// Delete namespace annotation
@@ -182,6 +184,13 @@ var _ = Describe("VerticalPodAutoscalerController Controller", Ordered, func() {
 			Expect(k8sClient.Get(testCtx, vpaNamespaceNN, vpaNamespace)).To(Succeed())
 			delete(vpaNamespace.Annotations, DefaultVPAControllerAnnotation)
 			Expect(k8sClient.Update(testCtx, vpaNamespace)).To(Succeed())
+
+			// Wait for the cache to observe the annotation removal
+			Eventually(func(g Gomega) {
+				ns := &corev1.Namespace{}
+				g.Expect(k8sClient.Get(testCtx, vpaNamespaceNN, ns)).To(Succeed())
+				g.Expect(ns.GetAnnotations()).NotTo(HaveKey(DefaultVPAControllerAnnotation))
+			}, timeout, interval).Should(Succeed())
 
 			// Trigger ensureVPAController
 			Expect(vpaReconciler.ensureVPAController(testCtx)).To(Succeed())

--- a/test/testdata/crd/0000_10_config-operator_01_apiservers-TechPreviewNoUpgrade.crd.yaml
+++ b/test/testdata/crd/0000_10_config-operator_01_apiservers-TechPreviewNoUpgrade.crd.yaml
@@ -1,0 +1,654 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
+  name: apiservers.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: APIServer
+    listKind: APIServerList
+    plural: apiservers
+    singular: apiserver
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            APIServer holds configuration (like serving certificates, client CA and CORS domains)
+            shared by all API servers in the system, among them especially kube-apiserver
+            and openshift-apiserver. The canonical name of an instance is 'cluster'.
+
+            Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              properties:
+                additionalCORSAllowedOrigins:
+                  description: |-
+                    additionalCORSAllowedOrigins lists additional, user-defined regular expressions describing hosts for which the
+                    API server allows access using the CORS headers. This may be needed to access the API and the integrated OAuth
+                    server from JavaScript applications.
+                    The values are regular expressions that correspond to the Golang regular expression language.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: atomic
+                audit:
+                  default:
+                    profile: Default
+                  description: |-
+                    audit specifies the settings for audit configuration to be applied to all OpenShift-provided
+                    API servers in the cluster.
+                  properties:
+                    customRules:
+                      description: |-
+                        customRules specify profiles per group. These profile take precedence over the
+                        top-level profile field if they apply. They are evaluation from top to bottom and
+                        the first one that matches, applies.
+                      items:
+                        description: |-
+                          AuditCustomRule describes a custom rule for an audit profile that takes precedence over
+                          the top-level profile.
+                        properties:
+                          group:
+                            description: group is a name of group a request user must be member of in order to this profile to apply.
+                            minLength: 1
+                            type: string
+                          profile:
+                            description: |-
+                              profile specifies the name of the desired audit policy configuration to be deployed to
+                              all OpenShift-provided API servers in the cluster.
+
+                              The following profiles are provided:
+                              - Default: the existing default policy.
+                              - WriteRequestBodies: like 'Default', but logs request and response HTTP payloads for
+                              write requests (create, update, patch).
+                              - AllRequestBodies: like 'WriteRequestBodies', but also logs request and response
+                              HTTP payloads for read requests (get, list).
+                              - None: no requests are logged at all, not even oauthaccesstokens and oauthauthorizetokens.
+
+                              If unset, the 'Default' profile is used as the default.
+                            enum:
+                              - Default
+                              - WriteRequestBodies
+                              - AllRequestBodies
+                              - None
+                            type: string
+                        required:
+                          - group
+                          - profile
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - group
+                      x-kubernetes-list-type: map
+                    profile:
+                      default: Default
+                      description: |-
+                        profile specifies the name of the desired top-level audit profile to be applied to all requests
+                        sent to any of the OpenShift-provided API servers in the cluster (kube-apiserver,
+                        openshift-apiserver and oauth-apiserver), with the exception of those requests that match
+                        one or more of the customRules.
+
+                        The following profiles are provided:
+                        - Default: default policy which means MetaData level logging with the exception of events
+                          (not logged at all), oauthaccesstokens and oauthauthorizetokens (both logged at RequestBody
+                          level).
+                        - WriteRequestBodies: like 'Default', but logs request and response HTTP payloads for
+                        write requests (create, update, patch).
+                        - AllRequestBodies: like 'WriteRequestBodies', but also logs request and response
+                        HTTP payloads for read requests (get, list).
+                        - None: no requests are logged at all, not even oauthaccesstokens and oauthauthorizetokens.
+
+                        Warning: It is not recommended to disable audit logging by using the `None` profile unless you
+                        are fully aware of the risks of not logging data that can be beneficial when troubleshooting issues.
+                        If you disable audit logging and a support situation arises, you might need to enable audit logging
+                        and reproduce the issue in order to troubleshoot properly.
+
+                        If unset, the 'Default' profile is used as the default.
+                      enum:
+                        - Default
+                        - WriteRequestBodies
+                        - AllRequestBodies
+                        - None
+                      type: string
+                  type: object
+                clientCA:
+                  description: |-
+                    clientCA references a ConfigMap containing a certificate bundle for the signers that will be recognized for
+                    incoming client certificates in addition to the operator managed signers. If this is empty, then only operator managed signers are valid.
+                    You usually only have to set this if you have your own PKI you wish to honor client certificates from.
+                    The ConfigMap must exist in the openshift-config namespace and contain the following required fields:
+                    - ConfigMap.Data["ca-bundle.crt"] - CA bundle.
+                  properties:
+                    name:
+                      description: name is the metadata.name of the referenced config map
+                      type: string
+                  required:
+                    - name
+                  type: object
+                encryption:
+                  description: encryption allows the configuration of encryption of resources at the datastore layer.
+                  properties:
+                    kms:
+                      description: |-
+                        kms defines the configuration for the external KMS instance that manages the encryption keys,
+                        when KMS encryption is enabled sensitive resources will be encrypted using keys managed by an
+                        externally configured KMS instance.
+
+                        The Key Management Service (KMS) instance provides symmetric encryption and is responsible for
+                        managing the lifecyle of the encryption keys outside of the control plane.
+                        This allows integration with an external provider to manage the data encryption keys securely.
+                      properties:
+                        type:
+                          description: |-
+                            type defines the kind of platform for the KMS provider.
+                            Allowed values are Vault.
+                            When set to Vault, the plugin connects to a HashiCorp Vault server for key management.
+                          enum:
+                            - Vault
+                          type: string
+                        vault:
+                          description: |-
+                            vault defines the configuration for the Vault KMS plugin.
+                            The plugin connects to a Vault Enterprise server that is managed
+                            by the user outside the purview of the control plane.
+                            This field must be set when type is Vault, and must be unset otherwise.
+                          properties:
+                            authentication:
+                              description: authentication defines the authentication method used to authenticate with Vault.
+                              properties:
+                                appRole:
+                                  description: |-
+                                    appRole defines the configuration for AppRole authentication.
+                                    This field must be set when type is AppRole, and must be unset otherwise.
+                                  properties:
+                                    secret:
+                                      description: |-
+                                        secret references a secret in the openshift-config namespace containing
+                                        the AppRole credentials used to authenticate with Vault.
+                                        The referenced Secret must contain two keys: "role-id" for the AppRole Role ID and "secret-id" for the AppRole Secret ID.
+                                      properties:
+                                        name:
+                                          description: |-
+                                            name is the metadata.name of the referenced secret in the openshift-config namespace.
+                                            The name must be a valid DNS subdomain name: it must contain no more than 253 characters,
+                                            contain only lowercase alphanumeric characters, '-' or '.', and start and end with an alphanumeric character.
+                                          maxLength: 253
+                                          minLength: 1
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  required:
+                                    - secret
+                                  type: object
+                                type:
+                                  description: |-
+                                    type defines the authentication method used to authenticate with Vault.
+                                    Allowed values are AppRole.
+                                    When set to AppRole, the plugin uses AppRole credentials to authenticate with Vault.
+                                  enum:
+                                    - AppRole
+                                  type: string
+                              required:
+                                - type
+                              type: object
+                            kmsPluginImage:
+                              description: |-
+                                kmsPluginImage specifies the container image for the HashiCorp Vault KMS plugin.
+
+                                The image must be a fully qualified OCI image pull spec with a SHA256 digest.
+                                The format is: host[:port][/namespace]/name@sha256:<digest>
+                                where the digest must be 64 characters long and consist only of lowercase hexadecimal characters, a-f and 0-9.
+                                The total length must be between 75 and 447 characters.
+
+                                Short names (e.g., "vault-plugin" or "hashicorp/vault-plugin") are not allowed.
+                                The registry hostname must be included and must contain at least one dot.
+                                Image tags (e.g., ":latest", ":v1.0.0") are not allowed.
+
+                                Consult the OpenShift documentation for compatible plugin versions with your cluster version,
+                                then obtain the image digest for that version from HashiCorp's container registry.
+
+                                For disconnected environments, mirror the plugin image to an accessible registry
+                                and reference the mirrored location with its digest.
+                              maxLength: 447
+                              minLength: 75
+                              type: string
+                            tls:
+                              description: |-
+                                tls contains the TLS configuration for connecting to the Vault server.
+                                When this field is not set, system default TLS settings are used.
+                              minProperties: 1
+                              properties:
+                                caBundle:
+                                  description: |-
+                                    caBundle references a ConfigMap in the openshift-config namespace containing
+                                    the CA certificate bundle used to verify the TLS connection to the Vault server.
+                                    The referenced ConfigMap must contain the CA bundle in the key "ca-bundle.crt".
+                                    When this field is not set, the system's trusted CA certificates are used.
+
+                                    The namespace for the ConfigMap is openshift-config.
+
+                                    Example ConfigMap:
+                                      apiVersion: v1
+                                      kind: ConfigMap
+                                      metadata:
+                                        name: vault-ca-bundle
+                                        namespace: openshift-config
+                                      data:
+                                        ca-bundle.crt: |
+                                          -----BEGIN CERTIFICATE-----
+                                          ...
+                                          -----END CERTIFICATE-----
+                                  properties:
+                                    name:
+                                      description: |-
+                                        name is the metadata.name of the referenced ConfigMap in the openshift-config namespace.
+                                        The name must be a valid DNS subdomain name: it must contain no more than 253 characters,
+                                        contain only lowercase alphanumeric characters, '-' or '.', and start and end with an alphanumeric character.
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                serverName:
+                                  description: |-
+                                    serverName specifies the Server Name Indication (SNI) to use when connecting to Vault via TLS.
+                                    This is useful when the Vault server's hostname doesn't match its TLS certificate.
+                                    When this field is not set, the hostname from vaultAddress is used for SNI.
+
+                                    The value must be a valid DNS hostname: it must contain no more than 253 characters,
+                                    contain only lowercase alphanumeric characters, '-' or '.', and start and end with an alphanumeric character.
+                                  maxLength: 253
+                                  minLength: 1
+                                  type: string
+                              type: object
+                            transitKey:
+                              description: |-
+                                transitKey specifies the name of the encryption key in Vault's Transit engine.
+                                This key is used to encrypt and decrypt data.
+
+                                The transit key must be between 1 and 512 characters, cannot contain forward slashes,
+                                and must only contain alphanumeric characters, hyphens, periods, and underscores.
+                              maxLength: 512
+                              minLength: 1
+                              type: string
+                            transitMount:
+                              description: |-
+                                transitMount specifies the mount path of the Vault Transit engine.
+
+                                The transit mount must be between 1 and 1024 characters, cannot start or
+                                end with a forward slash, cannot contain consecutive forward slashes, and
+                                must only contain RFC 3986 unreserved characters (alphanumeric, hyphen,
+                                period, underscore, tilde) and forward slashes as path separators.
+                              maxLength: 1024
+                              minLength: 1
+                              type: string
+                            vaultAddress:
+                              description: |-
+                                vaultAddress specifies the address of the HashiCorp Vault instance.
+                                The value must be a valid HTTPS URL containing only scheme, host, and optional port.
+                                Paths, user info, query parameters, and fragments are not allowed.
+
+                                Format: https://hostname[:port]
+                                Example: https://vault.example.com:8200
+
+                                The value must be between 1 and 512 characters.
+                              maxLength: 512
+                              minLength: 1
+                              type: string
+                            vaultNamespace:
+                              description: |-
+                                vaultNamespace specifies the Vault namespace where the Transit secrets engine is mounted.
+                                This is only applicable for Vault Enterprise installations.
+                                When this field is not set, no namespace is used.
+
+                                The value must be between 1 and 4096 characters.
+                                The namespace cannot end with a forward slash, cannot contain spaces, and cannot be one of the reserved strings: root, sys, audit, auth, cubbyhole, or identity.
+                              maxLength: 4096
+                              minLength: 1
+                              type: string
+                          required:
+                            - authentication
+                            - kmsPluginImage
+                            - transitKey
+                            - transitMount
+                            - vaultAddress
+                          type: object
+                      required:
+                        - type
+                      type: object
+                    type:
+                      description: |-
+                        type defines what encryption type should be used to encrypt resources at the datastore layer.
+                        When this field is unset (i.e. when it is set to the empty string), identity is implied.
+                        The behavior of unset can and will change over time.  Even if encryption is enabled by default,
+                        the meaning of unset may change to a different encryption type based on changes in best practices.
+
+                        When encryption is enabled, all sensitive resources shipped with the platform are encrypted.
+                        This list of sensitive resources can and will change over time.  The current authoritative list is:
+
+                          1. secrets
+                          2. configmaps
+                          3. routes.route.openshift.io
+                          4. oauthaccesstokens.oauth.openshift.io
+                          5. oauthauthorizetokens.oauth.openshift.io
+                      enum:
+                        - ""
+                        - identity
+                        - aescbc
+                        - aesgcm
+                        - KMS
+                      type: string
+                  type: object
+                servingCerts:
+                  description: |-
+                    servingCert is the TLS cert info for serving secure traffic. If not specified, operator managed certificates
+                    will be used for serving secure traffic.
+                  properties:
+                    namedCertificates:
+                      description: |-
+                        namedCertificates references secrets containing the TLS cert info for serving secure traffic to specific hostnames.
+                        If no named certificates are provided, or no named certificates match the server name as understood by a client,
+                        the defaultServingCertificate will be used.
+                      items:
+                        description: APIServerNamedServingCert maps a server DNS name, as understood by a client, to a certificate.
+                        properties:
+                          names:
+                            description: |-
+                              names is a optional list of explicit DNS names (leading wildcards allowed) that should use this certificate to
+                              serve secure traffic. If no names are provided, the implicit names will be extracted from the certificates.
+                              Exact names trump over wildcard names. Explicit names defined here trump over extracted implicit names.
+                            items:
+                              type: string
+                            maxItems: 64
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          servingCertificate:
+                            description: |-
+                              servingCertificate references a kubernetes.io/tls type secret containing the TLS cert info for serving secure traffic.
+                              The secret must exist in the openshift-config namespace and contain the following required fields:
+                              - Secret.Data["tls.key"] - TLS private key.
+                              - Secret.Data["tls.crt"] - TLS certificate.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced secret
+                                type: string
+                            required:
+                              - name
+                            type: object
+                        type: object
+                      maxItems: 32
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  type: object
+                tlsAdherence:
+                  description: |-
+                    tlsAdherence controls if components in the cluster adhere to the TLS security profile
+                    configured on this APIServer resource.
+
+                    Valid values are "LegacyAdheringComponentsOnly" and "StrictAllComponents".
+
+                    When set to "LegacyAdheringComponentsOnly", components that already honor the
+                    cluster-wide TLS profile continue to do so. Components that do not already honor
+                    it continue to use their individual TLS configurations.
+
+                    When set to "StrictAllComponents", all components must honor the configured TLS
+                    profile unless they have a component-specific TLS configuration that overrides
+                    it. This mode is recommended for security-conscious deployments and is required
+                    for certain compliance frameworks.
+
+                    Note: Some components such as Kubelet and IngressController have their own
+                    dedicated TLS configuration mechanisms via KubeletConfig and IngressController
+                    CRs respectively. When these component-specific TLS configurations are set,
+                    they take precedence over the cluster-wide tlsSecurityProfile. When not set,
+                    these components fall back to the cluster-wide default.
+
+                    Components that encounter an unknown value for tlsAdherence should treat it
+                    as "StrictAllComponents" and log a warning to ensure forward compatibility
+                    while defaulting to the more secure behavior.
+
+                    This field is optional.
+                    When omitted, this means the user has no opinion and the platform is left
+                    to choose reasonable defaults. These defaults are subject to change over time.
+                    The current default is LegacyAdheringComponentsOnly.
+
+                    Once set, this field may be changed to a different value, but may not be removed.
+                  enum:
+                    - LegacyAdheringComponentsOnly
+                    - StrictAllComponents
+                  type: string
+                tlsSecurityProfile:
+                  description: |-
+                    tlsSecurityProfile specifies settings for TLS connections for externally exposed servers.
+
+                    When omitted, this means no opinion and the platform is left to choose a reasonable default, which is subject to change over time.
+                    The current default is the Intermediate profile.
+                  properties:
+                    custom:
+                      description: |-
+                        custom is a user-defined TLS security profile. Be extremely careful using a custom
+                        profile as invalid configurations can be catastrophic.
+
+                        The supported groups list for this profile is empty by default.
+
+                        An example custom profile looks like this:
+
+                          minTLSVersion: VersionTLS11
+                          ciphers:
+                            - ECDHE-ECDSA-CHACHA20-POLY1305
+                            - ECDHE-RSA-CHACHA20-POLY1305
+                            - ECDHE-RSA-AES128-GCM-SHA256
+                            - ECDHE-ECDSA-AES128-GCM-SHA256
+                      nullable: true
+                      properties:
+                        ciphers:
+                          description: |-
+                            ciphers is used to specify the cipher algorithms that are negotiated
+                            during the TLS handshake. Operators may remove entries that their operands
+                            do not support. For example, to use only ECDHE-RSA-AES128-GCM-SHA256 (yaml):
+
+                              ciphers:
+                                - ECDHE-RSA-AES128-GCM-SHA256
+
+                            TLS 1.3 cipher suites (e.g. TLS_AES_128_GCM_SHA256) are not configurable
+                            and are always enabled when TLS 1.3 is negotiated.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        groups:
+                          description: |-
+                            groups is an optional, ordered field used to specify the supported groups (formerly known as
+                            elliptic curves) that are used during the TLS handshake.  The order of the groups represents
+                            a suggested preference, with the most preferred group first. Note that not all platform
+                            components honor the ordering: Go-based components use Go's internal preference order and
+                            treat this list as a filter of allowed groups rather than an ordered preference.
+                            Operators may remove entries their operands do not support.
+
+                            When omitted, this means no opinion and the platform is left to choose reasonable defaults which are
+                            subject to change over time and may be different per platform component depending on the underlying TLS
+                            libraries they use. If specified, the list must contain at least one and at most 7 groups,
+                            and each group must be unique.
+
+                            For example, to use X25519 and secp256r1 (yaml):
+
+                              groups:
+                                - X25519
+                                - secp256r1
+                          items:
+                            description: |-
+                              TLSGroup is a supported group identifier that can be used in TLSProfile.Groups.
+                              There is a one-to-one mapping between these names and the group IDs defined
+                              in Go's crypto/tls package based on IANA's "TLS Supported Groups" registry:
+                              https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8
+                              Note that X25519MLKEM768 is a post-quantum hybrid group that is not
+                              FIPS-approved and should be ignored by components running in FIPS mode.
+                            enum:
+                              - X25519
+                              - secp256r1
+                              - secp384r1
+                              - secp521r1
+                              - X25519MLKEM768
+                              - SecP256r1MLKEM768
+                              - SecP384r1MLKEM1024
+                            type: string
+                          maxItems: 7
+                          minItems: 1
+                          type: array
+                          x-kubernetes-list-type: set
+                        minTLSVersion:
+                          description: |-
+                            minTLSVersion is used to specify the minimal version of the TLS protocol
+                            that is negotiated during the TLS handshake. For example, to use TLS
+                            versions 1.1, 1.2 and 1.3 (yaml):
+
+                              minTLSVersion: VersionTLS11
+                          enum:
+                            - VersionTLS10
+                            - VersionTLS11
+                            - VersionTLS12
+                            - VersionTLS13
+                          type: string
+                      type: object
+                    intermediate:
+                      description: |-
+                        intermediate is a TLS profile for use when you do not need compatibility with
+                        legacy clients and want to remain highly secure while being compatible with
+                        most clients currently in use.
+
+                        The supported groups list includes by default the following groups
+                        in suggested preference order (ordering may not be honored by all implementations):
+                        X25519MLKEM768, X25519, secp256r1, secp384r1.
+
+                        This profile is equivalent to a Custom profile specified as:
+                          minTLSVersion: VersionTLS12
+                          ciphers:
+                            - TLS_AES_128_GCM_SHA256
+                            - TLS_AES_256_GCM_SHA384
+                            - TLS_CHACHA20_POLY1305_SHA256
+                            - ECDHE-ECDSA-AES128-GCM-SHA256
+                            - ECDHE-RSA-AES128-GCM-SHA256
+                            - ECDHE-ECDSA-AES256-GCM-SHA384
+                            - ECDHE-RSA-AES256-GCM-SHA384
+                            - ECDHE-ECDSA-CHACHA20-POLY1305
+                            - ECDHE-RSA-CHACHA20-POLY1305
+                      nullable: true
+                      type: object
+                    modern:
+                      description: |-
+                        modern is a TLS security profile for use with clients that support TLS 1.3 and
+                        do not need backward compatibility for older clients.
+                        The supported groups list includes by default the following groups
+                        in suggested preference order (ordering may not be honored by all implementations):
+                        X25519MLKEM768, X25519, secp256r1, secp384r1.
+                        This profile is equivalent to a Custom profile specified as:
+                          minTLSVersion: VersionTLS13
+                          ciphers:
+                            - TLS_AES_128_GCM_SHA256
+                            - TLS_AES_256_GCM_SHA384
+                            - TLS_CHACHA20_POLY1305_SHA256
+                      nullable: true
+                      type: object
+                    old:
+                      description: |-
+                        old is a TLS profile for use when services need to be accessed by very old
+                        clients or libraries and should be used only as a last resort.
+
+                        The supported groups list includes by default the following groups
+                        in suggested preference order (ordering may not be honored by all implementations):
+                        X25519MLKEM768, X25519, secp256r1, secp384r1.
+
+                        This profile is equivalent to a Custom profile specified as:
+                          minTLSVersion: VersionTLS10
+                          ciphers:
+                            - TLS_AES_128_GCM_SHA256
+                            - TLS_AES_256_GCM_SHA384
+                            - TLS_CHACHA20_POLY1305_SHA256
+                            - ECDHE-ECDSA-AES128-GCM-SHA256
+                            - ECDHE-RSA-AES128-GCM-SHA256
+                            - ECDHE-ECDSA-AES256-GCM-SHA384
+                            - ECDHE-RSA-AES256-GCM-SHA384
+                            - ECDHE-ECDSA-CHACHA20-POLY1305
+                            - ECDHE-RSA-CHACHA20-POLY1305
+                            - ECDHE-ECDSA-AES128-SHA256
+                            - ECDHE-RSA-AES128-SHA256
+                            - ECDHE-ECDSA-AES128-SHA
+                            - ECDHE-RSA-AES128-SHA
+                            - ECDHE-ECDSA-AES256-SHA384
+                            - ECDHE-RSA-AES256-SHA384
+                            - ECDHE-ECDSA-AES256-SHA
+                            - ECDHE-RSA-AES256-SHA
+                            - AES128-GCM-SHA256
+                            - AES256-GCM-SHA384
+                            - AES128-SHA256
+                            - AES256-SHA256
+                            - AES128-SHA
+                            - AES256-SHA
+                            - DES-CBC3-SHA
+                      nullable: true
+                      type: object
+                    type:
+                      description: |-
+                        type is one of Old, Intermediate, Modern or Custom. Custom provides the
+                        ability to specify individual TLS security profile parameters.
+
+                        The cipher and groups lists in these profiles are based on version 5.8 of the
+                        Mozilla Server Side TLS configuration guidelines.
+                        See: https://ssl-config.mozilla.org/guidelines/5.8.json
+
+                        The groups are listed in suggested preference order, with the most preferred group first.
+                        Note that not all platform components honor the ordering: Go-based components use Go's
+                        internal preference order and treat this list as a filter of allowed groups rather than
+                        an ordered preference.
+                        Note that X25519MLKEM768 is a post-quantum hybrid group that is not
+                        FIPS-approved and should be ignored by components running in FIPS mode.
+
+                        The profiles are intent based, so they may change over time as new ciphers are
+                        developed and existing ciphers are found to be insecure. Depending on
+                        precisely which ciphers are available to a process, the list may be reduced.
+                      enum:
+                        - Old
+                        - Intermediate
+                        - Modern
+                        - Custom
+                      type: string
+                  type: object
+              type: object
+            status:
+              description: status holds observed values from the cluster. They may not be overridden.
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}


### PR DESCRIPTION
To fix failures of the flavor
```
 KUBEBUILDER_ASSETS="/go/src/github.com/openshift/vertical-pod-autoscaler-operator/bin/k8s/1.30.3-linux-amd64" go test $(go list ./... | grep -v /e2e) -coverprofile cover.out
	github.com/openshift/vertical-pod-autoscaler-operator/api/v1		coverage: 0.0% of statements
	github.com/openshift/vertical-pod-autoscaler-operator/cmd		coverage: 0.0% of statements
	github.com/openshift/vertical-pod-autoscaler-operator/cmd/testutil/json2yaml		coverage: 0.0% of statements
	github.com/openshift/vertical-pod-autoscaler-operator/cmd/testutil/yaml2json		coverage: 0.0% of statements
Running Suite: Controller Suite - /go/src/github.com/openshift/vertical-pod-autoscaler-operator/internal/controller/verticalpodautoscaler
=========================================================================================================================================
Random Seed: 1781674692
Will run 3 of 3 specs
2026-06-17T05:38:14Z	ERROR	controller-runtime.source.Kind	if kind is a CRD, it should be installed before calling Start	{"kind": "APIServer.config.openshift.io", "error": "no matches for kind \"APIServer\" in version \"config.openshift.io/v1\""}
sigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind[...]).Start.func1.1
	/go/src/github.com/openshift/vertical-pod-autoscaler-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/source/kind.go:75
k8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext.func1
	/go/src/github.com/openshift/vertical-pod-autoscaler-operator/vendor/k8s.io/apimachinery/pkg/util/wait/loop.go:53
k8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext
	/go/src/github.com/openshift/vertical-pod-autoscaler-operator/vendor/k8s.io/apimachinery/pkg/util/wait/loop.go:54
k8s.io/apimachinery/pkg/util/wait.PollUntilContextCancel
	/go/src/github.com/openshift/vertical-pod-autoscaler-operator/vendor/k8s.io/apimachinery/pkg/util/wait/poll.go:33
sigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind[...]).Start.func1
	/go/src/github.com/openshift/vertical-pod-autoscaler-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/source/kind.go:68
I0617 05:38:14.909690   37735 verticalpodautoscaler_controller.go:490] No VerticalPodAutoscalerController exists. Creating instance 'openshift-vertical-pod-autoscaler/default'
••
------------------------------
• [FAILED] [5.005 seconds] 
```

Also fix flakes in `VerticalPodAutoscalerController Controller VPA Controller creation upon startup [It] should add annotation to namespace and not create default controller when controller exists on startup ` by wrapping it in an eventually