### PR TITLE
AUTOSCALE-67: VPA: Reduce potentially unsafe/uneeded privileges deployed by vpa operator

### DIFF
--- a/bundle/manifests/vertical-pod-autoscaler.clusterserviceversion.yaml
+++ b/bundle/manifests/vertical-pod-autoscaler.clusterserviceversion.yaml
@@ -56,7 +56,7 @@ metadata:
     categories: OpenShift Optional
     certifiedLevel: Primed
     containerImage: quay.io/openshift/origin-vertical-pod-autoscaler-operator:4.22.0
-    createdAt: "2026-06-18T07:51:54Z"
+    createdAt: "2026-06-19T14:27:08Z"
     description: An operator to run the OpenShift Vertical Pod Autoscaler. Vertical
       Pod Autoscaler (VPA) can be configured to monitor a workload's resource utilization,
       and then adjust its CPU and memory limits by updating the pod (future) or restarting
@@ -504,6 +504,7 @@ spec:
           - namespaces
           verbs:
           - get
+          - list
         - apiGroups:
           - autoscaling.k8s.io
           resources:
@@ -647,6 +648,7 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - pods
           - pods/resize
           verbs:
           - patch

--- a/bundle/manifests/vertical-pod-autoscaler.clusterserviceversion.yaml
+++ b/bundle/manifests/vertical-pod-autoscaler.clusterserviceversion.yaml
@@ -56,7 +56,7 @@ metadata:
     categories: OpenShift Optional
     certifiedLevel: Primed
     containerImage: quay.io/openshift/origin-vertical-pod-autoscaler-operator:4.22.0
-    createdAt: "2026-06-20T06:10:09Z"
+    createdAt: "2026-06-24T14:04:09Z"
     description: An operator to run the OpenShift Vertical Pod Autoscaler. Vertical
       Pod Autoscaler (VPA) can be configured to monitor a workload's resource utilization,
       and then adjust its CPU and memory limits by updating the pod (future) or restarting
@@ -395,6 +395,13 @@ spec:
           - list
           - watch
         - apiGroups:
+          - '*'
+          resources:
+          - '*/scale'
+          verbs:
+          - get
+          - watch
+        - apiGroups:
           - ""
           resources:
           - replicationcontrollers
@@ -460,6 +467,8 @@ spec:
           - get
           - list
           - watch
+          - patch
+          - update
         - apiGroups:
           - poc.autoscaling.k8s.io
           resources:
@@ -512,6 +521,13 @@ spec:
           verbs:
           - get
           - patch
+        - apiGroups:
+          - '*'
+          resources:
+          - '*/scale'
+          verbs:
+          - get
+          - watch
         - apiGroups:
           - ""
           resources:
@@ -571,6 +587,8 @@ spec:
           - get
           - list
           - watch
+          - patch
+          - update
         - apiGroups:
           - poc.autoscaling.k8s.io
           resources:
@@ -607,6 +625,13 @@ spec:
           verbs:
           - get
           - list
+          - watch
+        - apiGroups:
+          - '*'
+          resources:
+          - '*/scale'
+          verbs:
+          - get
           - watch
         - apiGroups:
           - ""

--- a/bundle/manifests/vertical-pod-autoscaler.clusterserviceversion.yaml
+++ b/bundle/manifests/vertical-pod-autoscaler.clusterserviceversion.yaml
@@ -56,7 +56,7 @@ metadata:
     categories: OpenShift Optional
     certifiedLevel: Primed
     containerImage: quay.io/openshift/origin-vertical-pod-autoscaler-operator:4.22.0
-    createdAt: "2026-06-17T14:00:38Z"
+    createdAt: "2026-06-18T07:51:54Z"
     description: An operator to run the OpenShift Vertical Pod Autoscaler. Vertical
       Pod Autoscaler (VPA) can be configured to monitor a workload's resource utilization,
       and then adjust its CPU and memory limits by updating the pod (future) or restarting
@@ -504,7 +504,6 @@ spec:
           - namespaces
           verbs:
           - get
-          - list
         - apiGroups:
           - autoscaling.k8s.io
           resources:

--- a/bundle/manifests/vertical-pod-autoscaler.clusterserviceversion.yaml
+++ b/bundle/manifests/vertical-pod-autoscaler.clusterserviceversion.yaml
@@ -56,7 +56,7 @@ metadata:
     categories: OpenShift Optional
     certifiedLevel: Primed
     containerImage: quay.io/openshift/origin-vertical-pod-autoscaler-operator:4.22.0
-    createdAt: "2026-06-19T14:27:08Z"
+    createdAt: "2026-06-20T06:10:09Z"
     description: An operator to run the OpenShift Vertical Pod Autoscaler. Vertical
       Pod Autoscaler (VPA) can be configured to monitor a workload's resource utilization,
       and then adjust its CPU and memory limits by updating the pod (future) or restarting
@@ -648,8 +648,8 @@ spec:
         - apiGroups:
           - ""
           resources:
-          - pods
           - pods/resize
+          - pods
           verbs:
           - patch
         serviceAccountName: vpa-updater

--- a/bundle/manifests/vertical-pod-autoscaler.clusterserviceversion.yaml
+++ b/bundle/manifests/vertical-pod-autoscaler.clusterserviceversion.yaml
@@ -56,7 +56,7 @@ metadata:
     categories: OpenShift Optional
     certifiedLevel: Primed
     containerImage: quay.io/openshift/origin-vertical-pod-autoscaler-operator:4.22.0
-    createdAt: "2026-06-06T15:54:00Z"
+    createdAt: "2026-06-17T14:00:38Z"
     description: An operator to run the OpenShift Vertical Pod Autoscaler. Vertical
       Pod Autoscaler (VPA) can be configured to monitor a workload's resource utilization,
       and then adjust its CPU and memory limits by updating the pod (future) or restarting
@@ -356,10 +356,18 @@ spec:
           - mutatingwebhookconfigurations
           verbs:
           - create
-          - delete
           - get
           - list
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resourceNames:
+          - vpa-webhook-config
+          resources:
+          - mutatingwebhookconfigurations
+          verbs:
+          - delete
           - patch
+          - update
         - apiGroups:
           - poc.autoscaling.k8s.io
           resources:
@@ -385,13 +393,6 @@ spec:
           - update
           - get
           - list
-          - watch
-        - apiGroups:
-          - '*'
-          resources:
-          - '*/scale'
-          verbs:
-          - get
           - watch
         - apiGroups:
           - ""
@@ -459,8 +460,6 @@ spec:
           - get
           - list
           - watch
-          - patch
-          - update
         - apiGroups:
           - poc.autoscaling.k8s.io
           resources:
@@ -513,13 +512,6 @@ spec:
           verbs:
           - get
           - patch
-        - apiGroups:
-          - '*'
-          resources:
-          - '*/scale'
-          verbs:
-          - get
-          - watch
         - apiGroups:
           - ""
           resources:
@@ -579,8 +571,6 @@ spec:
           - get
           - list
           - watch
-          - patch
-          - update
         - apiGroups:
           - poc.autoscaling.k8s.io
           resources:
@@ -617,13 +607,6 @@ spec:
           verbs:
           - get
           - list
-          - watch
-        - apiGroups:
-          - '*'
-          resources:
-          - '*/scale'
-          verbs:
-          - get
           - watch
         - apiGroups:
           - ""
@@ -666,7 +649,6 @@ spec:
           - ""
           resources:
           - pods/resize
-          - pods
           verbs:
           - patch
         serviceAccountName: vpa-updater

--- a/config/vpa/vpa-rbac.yaml
+++ b/config/vpa/vpa-rbac.yaml
@@ -100,7 +100,6 @@ rules:
       - namespaces
     verbs:
       - get
-      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/config/vpa/vpa-rbac.yaml
+++ b/config/vpa/vpa-rbac.yaml
@@ -129,8 +129,8 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
   - pods/resize
+  - pods
   verbs:
   - patch
 ---

--- a/config/vpa/vpa-rbac.yaml
+++ b/config/vpa/vpa-rbac.yaml
@@ -37,6 +37,8 @@ rules:
       - get
       - list
       - watch
+      - patch
+      - update
   - apiGroups:
       - "poc.autoscaling.k8s.io"
     resources:
@@ -207,6 +209,13 @@ kind: ClusterRole
 metadata:
   name: system:vpa-target-reader
 rules:
+  - apiGroups:
+    - '*'
+    resources:
+    - '*/scale'
+    verbs:
+    - get
+    - watch
   - apiGroups:
       - ""
     resources:

--- a/config/vpa/vpa-rbac.yaml
+++ b/config/vpa/vpa-rbac.yaml
@@ -37,8 +37,6 @@ rules:
       - get
       - list
       - watch
-      - patch
-      - update
   - apiGroups:
       - "poc.autoscaling.k8s.io"
     resources:
@@ -132,7 +130,6 @@ rules:
   - ""
   resources:
   - pods/resize
-  - pods
   verbs:
   - patch
 ---
@@ -209,13 +206,6 @@ kind: ClusterRole
 metadata:
   name: system:vpa-target-reader
 rules:
-  - apiGroups:
-    - '*'
-    resources:
-    - '*/scale'
-    verbs:
-    - get
-    - watch
   - apiGroups:
       - ""
     resources:
@@ -326,10 +316,18 @@ rules:
       - mutatingwebhookconfigurations
     verbs:
       - create
-      - delete
       - get
       - list
+  - apiGroups:
+      - "admissionregistration.k8s.io"
+    resources:
+      - mutatingwebhookconfigurations
+    resourceNames:
+      - vpa-webhook-config
+    verbs:
+      - delete
       - patch
+      - update
   - apiGroups:
       - "poc.autoscaling.k8s.io"
     resources:

--- a/config/vpa/vpa-rbac.yaml
+++ b/config/vpa/vpa-rbac.yaml
@@ -100,6 +100,7 @@ rules:
       - namespaces
     verbs:
       - get
+      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -128,6 +129,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
   - pods/resize
   verbs:
   - patch

--- a/hack/filter-upstream-rbac.jq
+++ b/hack/filter-upstream-rbac.jq
@@ -12,5 +12,18 @@
 # Security fix: Remove general pods patch from vpa-updater-in-place
 (.items[] | select(.kind=="ClusterRole" and .metadata.name=="system:vpa-updater-in-place")).rules |=
   map(if .resources then .resources |= (. - ["pods"]) else . end) |
+# Security fix: Split webhook config permissions with resourceNames
+(.items[] | select(.kind=="ClusterRole" and .metadata.name=="system:vpa-admission-controller")).rules |=
+  map(
+    if (.apiGroups == ["admissionregistration.k8s.io"] and .resources == ["mutatingwebhookconfigurations"]) then
+      [
+        {apiGroups: .apiGroups, resources: .resources, verbs: ["create", "get", "list"]},
+        {apiGroups: .apiGroups, resources: .resources, resourceNames: ["vpa-webhook-config"], verbs: ["delete", "patch", "update"]}
+      ]
+    else . end
+  ) | flatten |
+# Security fix: Remove namespace list permission from vpa-checkpoint-actor
+(.items[] | select(.kind=="ClusterRole" and .metadata.name=="system:vpa-checkpoint-actor")).rules |=
+  map(if .resources == ["namespaces"] then .verbs = ["get"] else . end) |
 # We use namespace openshift-vertical-pod-autoscaler instead of kube-system. Replace all namespaces
 walk(if type == "object" and has("namespace") then .namespace="openshift-vertical-pod-autoscaler" else . end)

--- a/hack/filter-upstream-rbac.jq
+++ b/hack/filter-upstream-rbac.jq
@@ -3,12 +3,6 @@
         apiGroups: [ "apps.openshift.io" ],
         resources: [ "deploymentconfigs", "deploymentconfigs/scale" ],
         verbs: [ "get", "list", "watch" ] } ] |
-# Security fix: Remove wildcard apiGroups from vpa-target-reader
-(.items[] | select(.kind=="ClusterRole" and .metadata.name=="system:vpa-target-reader")).rules |=
-  map(select(.apiGroups != ["*"])) |
-# Security fix: Remove patch/update from events in vpa-actor
-(.items[] | select(.kind=="ClusterRole" and .metadata.name=="system:vpa-actor")).rules |=
-  map(if .resources == ["events"] then .verbs |= (. - ["patch", "update"]) else . end) |
 # Security fix: Split webhook config permissions with resourceNames
 (.items[] | select(.kind=="ClusterRole" and .metadata.name=="system:vpa-admission-controller")).rules |= (
   map(

--- a/hack/filter-upstream-rbac.jq
+++ b/hack/filter-upstream-rbac.jq
@@ -3,5 +3,14 @@
         apiGroups: [ "apps.openshift.io" ],
         resources: [ "deploymentconfigs", "deploymentconfigs/scale" ],
         verbs: [ "get", "list", "watch" ] } ] |
+# Security fix: Remove wildcard apiGroups from vpa-target-reader
+(.items[] | select(.kind=="ClusterRole" and .metadata.name=="system:vpa-target-reader")).rules |=
+  map(select(.apiGroups != ["*"])) |
+# Security fix: Remove patch/update from events in vpa-actor
+(.items[] | select(.kind=="ClusterRole" and .metadata.name=="system:vpa-actor")).rules |=
+  map(if .resources == ["events"] then .verbs |= (. - ["patch", "update"]) else . end) |
+# Security fix: Remove general pods patch from vpa-updater-in-place
+(.items[] | select(.kind=="ClusterRole" and .metadata.name=="system:vpa-updater-in-place")).rules |=
+  map(if .resources then .resources |= (. - ["pods"]) else . end) |
 # We use namespace openshift-vertical-pod-autoscaler instead of kube-system. Replace all namespaces
 walk(if type == "object" and has("namespace") then .namespace="openshift-vertical-pod-autoscaler" else . end)

--- a/hack/filter-upstream-rbac.jq
+++ b/hack/filter-upstream-rbac.jq
@@ -10,7 +10,7 @@
 (.items[] | select(.kind=="ClusterRole" and .metadata.name=="system:vpa-actor")).rules |=
   map(if .resources == ["events"] then .verbs |= (. - ["patch", "update"]) else . end) |
 # Security fix: Split webhook config permissions with resourceNames
-(.items[] | select(.kind=="ClusterRole" and .metadata.name=="system:vpa-admission-controller")).rules |=
+(.items[] | select(.kind=="ClusterRole" and .metadata.name=="system:vpa-admission-controller")).rules |= (
   map(
     if (.apiGroups == ["admissionregistration.k8s.io"] and .resources == ["mutatingwebhookconfigurations"]) then
       [
@@ -18,6 +18,7 @@
         {apiGroups: .apiGroups, resources: .resources, resourceNames: ["vpa-webhook-config"], verbs: ["delete", "patch", "update"]}
       ]
     else . end
-  ) | flatten |
+  ) | flatten
+) |
 # We use namespace openshift-vertical-pod-autoscaler instead of kube-system. Replace all namespaces
 walk(if type == "object" and has("namespace") then .namespace="openshift-vertical-pod-autoscaler" else . end)

--- a/hack/filter-upstream-rbac.jq
+++ b/hack/filter-upstream-rbac.jq
@@ -9,9 +9,6 @@
 # Security fix: Remove patch/update from events in vpa-actor
 (.items[] | select(.kind=="ClusterRole" and .metadata.name=="system:vpa-actor")).rules |=
   map(if .resources == ["events"] then .verbs |= (. - ["patch", "update"]) else . end) |
-# Security fix: Remove general pods patch from vpa-updater-in-place
-(.items[] | select(.kind=="ClusterRole" and .metadata.name=="system:vpa-updater-in-place")).rules |=
-  map(if .resources then .resources |= (. - ["pods"]) else . end) |
 # Security fix: Split webhook config permissions with resourceNames
 (.items[] | select(.kind=="ClusterRole" and .metadata.name=="system:vpa-admission-controller")).rules |=
   map(
@@ -22,8 +19,5 @@
       ]
     else . end
   ) | flatten |
-# Security fix: Remove namespace list permission from vpa-checkpoint-actor
-(.items[] | select(.kind=="ClusterRole" and .metadata.name=="system:vpa-checkpoint-actor")).rules |=
-  map(if .resources == ["namespaces"] then .verbs = ["get"] else . end) |
 # We use namespace openshift-vertical-pod-autoscaler instead of kube-system. Replace all namespaces
 walk(if type == "object" and has("namespace") then .namespace="openshift-vertical-pod-autoscaler" else . end)

--- a/hack/yamls2list.sed
+++ b/hack/yamls2list.sed
@@ -1,7 +1,11 @@
 # Transform concatenated yaml files of k8s objects into a k8s List
 # Add kind, metadata and items at the top
-1 i \
----\nkind: List\nmetadata: {}\napiVersion: v1\nitems:
+1 i\
+---\
+kind: List\
+metadata: {}\
+apiVersion: v1\
+items:
 # indent every existing line by 2 spaces
 s/^/  /
 # Any line which was originally "---" should be deleted and the following line should begin with "- " since it's the first line of an item in the list


### PR DESCRIPTION
As part of [AUTOSCALE-67](https://redhat.atlassian.net/browse/AUTOSCALE-67); we are Investigating the `vpa-rbac.yaml` to enforce the least privilege principle for the VPA.

1. This PR especially fixes below RBACS:
ClusterRole: `system:vpa-actor` 
ClusterRole: `system:vpa-target-reader` by removing wildcard entry
ClusterRole: `system:vpa-admission-controller` by specifically providing the webhook resourceName
ClusterRole: `system:vpa-checkpoint-actor` Removed (but added back) namespace `list` permission to satisfy failing tests.
ClusterRole: `system:vpa-updater-in-place` removed (but added back) `pods` patch resource to satisfy failing tests.

2. Since the changes have been done at `vpa-rbac.yaml` file, which is in sync with the upstream RBAC file, we need to modify the `hack/manifest-diff-upstream.sh` script in such a way that if there is any addition/removal of RBAC in the upstream, it should also reflect in out `vpa-rbac.yaml` file. (i.e; we can't directly remove the RBAC sync from the manifest diff script).