### PR TITLE
[release-4.18]: OCPBUGS-98714: Add RBAC for operator to read infrastructures

### DIFF
--- a/bundle/manifests/vertical-pod-autoscaler.clusterserviceversion.yaml
+++ b/bundle/manifests/vertical-pod-autoscaler.clusterserviceversion.yaml
@@ -277,6 +277,12 @@ spec:
           verbs:
           - update
         - apiGroups:
+          - config.openshift.io
+          resources:
+          - infrastructures
+          verbs:
+          - get
+        - apiGroups:
           - autoscaling.openshift.io
           resources:
           - verticalpodautoscalercontrollers/status

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -53,6 +53,12 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - infrastructures
+  verbs:
+  - get
+- apiGroups:
   - autoscaling.openshift.io
   resources:
   - verticalpodautoscalercontrollers/status


### PR DESCRIPTION
Add config.openshift.io/infrastructures get permission to the ClusterRole and CSV so the operator can detect HCP topology at startup

Note: this was inadvertantly dropped during the cherry-pick process from 4.21 to 4.20 and is missing from 4.18-4.20. It was originally in the commit titled:

>  Restore master scheduling for operator, fix RBAC for HCP detection

This fixes the incomplete #244 