### PR TITLE
[4.17] OCPBUGS-98866: Fix VPA installation on HCP clusters and reduce RBAC permissions

### DIFF
--- a/install/deploy/02_vpa-rbac.yaml
+++ b/install/deploy/02_vpa-rbac.yaml
@@ -376,28 +376,74 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
   - services
   verbs:
-  - create
   - get
-  - update
   - list
   - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
 - apiGroups:
   - autoscaling.openshift.io
   resources:
-  - "*"
+  - verticalpodautoscalercontrollers
   verbs:
-  - "*"
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - autoscaling.openshift.io
+  resources:
+  - verticalpodautoscalercontrollers/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - autoscaling.openshift.io
+  resources:
+  - verticalpodautoscalercontrollers/finalizers
+  verbs:
+  - update
 - apiGroups:
   - config.openshift.io
   resources:
-  - verticalpodoperatorcontrollers
-  - verticalpodoperatorcontrollers/status
+  - clusteroperators
+  - clusteroperators/status
   verbs:
   - create
   - get
   - update
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - infrastructures
+  verbs:
+  - get
 
 ---
 kind: Role
@@ -409,27 +455,59 @@ rules:
 - apiGroups:
   - autoscaling.openshift.io
   resources:
-  - "*"
+  - verticalpodautoscalercontrollers
   verbs:
-  - "*"
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - autoscaling.openshift.io
+  resources:
+  - verticalpodautoscalercontrollers/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - autoscaling.openshift.io
+  resources:
+  - verticalpodautoscalercontrollers/finalizers
+  verbs:
+  - update
 - apiGroups:
   - apps
   resources:
   - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
   verbs:
-  - "*"
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
 - apiGroups:
   - ""
   resources:
-  - pods
   - events
-  - configmaps
-  - secrets
   verbs:
-  - "*"
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
 
 ---
 kind: RoleBinding

--- a/install/deploy/03_deployment.yaml
+++ b/install/deploy/03_deployment.yaml
@@ -53,6 +53,7 @@ spec:
           seccompProfile:
             type: RuntimeDefault
       nodeSelector:
+        kubernetes.io/os: linux
         node-role.kubernetes.io/master: ""
       restartPolicy: Always
       securityContext:

--- a/manifests/stable/vertical-pod-autoscaler.clusterserviceversion.yaml
+++ b/manifests/stable/vertical-pod-autoscaler.clusterserviceversion.yaml
@@ -100,28 +100,74 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - configmaps
           - services
           verbs:
-          - create
           - get
-          - update
           - list
           - watch
+          - create
+          - update
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
         - apiGroups:
           - autoscaling.openshift.io
           resources:
-          - "*"
+          - verticalpodautoscalercontrollers
           verbs:
-          - "*"
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - autoscaling.openshift.io
+          resources:
+          - verticalpodautoscalercontrollers/status
+          verbs:
+          - get
+          - update
+          - patch
+        - apiGroups:
+          - autoscaling.openshift.io
+          resources:
+          - verticalpodautoscalercontrollers/finalizers
+          verbs:
+          - update
         - apiGroups:
           - config.openshift.io
           resources:
-          - verticalpodoperatorcontrollers
-          - verticalpodoperatorcontrollers/status
+          - clusteroperators
+          - clusteroperators/status
           verbs:
           - create
           - get
           - update
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - infrastructures
+          verbs:
+          - get
       - serviceAccountName: vpa-updater
         rules:
         # from ClusterRole system:evictioner
@@ -478,27 +524,59 @@ spec:
         - apiGroups:
           - autoscaling.openshift.io
           resources:
-          - "*"
+          - verticalpodautoscalercontrollers
           verbs:
-          - "*"
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - autoscaling.openshift.io
+          resources:
+          - verticalpodautoscalercontrollers/status
+          verbs:
+          - get
+          - update
+          - patch
+        - apiGroups:
+          - autoscaling.openshift.io
+          resources:
+          - verticalpodautoscalercontrollers/finalizers
+          verbs:
+          - update
         - apiGroups:
           - apps
           resources:
           - deployments
-          - daemonsets
-          - replicasets
-          - statefulsets
           verbs:
-          - "*"
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
         - apiGroups:
           - ""
           resources:
-          - pods
           - events
-          - configmaps
-          - secrets
           verbs:
-          - "*"
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
       deployments:
       - name: vertical-pod-autoscaler-operator
         spec:
@@ -548,6 +626,7 @@ spec:
                   seccompProfile:
                     type: RuntimeDefault
               nodeSelector:
+                kubernetes.io/os: linux
                 node-role.kubernetes.io/master: ""
               restartPolicy: Always
               securityContext:

--- a/pkg/controller/verticalpodautoscaler/verticalpodautoscaler_controller.go
+++ b/pkg/controller/verticalpodautoscaler/verticalpodautoscaler_controller.go
@@ -130,6 +130,10 @@ type Config struct {
 	Verbosity int
 	// Additional arguments passed to the vertical-pod-autoscaler.
 	ExtraArgs string
+	// IsExternalControlPlane indicates whether the cluster has an external
+	// control plane (HCP/Hosted Control Plane topology). When true, VPA
+	// components should schedule on worker nodes instead of master nodes.
+	IsExternalControlPlane bool
 }
 
 var _ reconcile.Reconciler = &Reconciler{}
@@ -681,6 +685,44 @@ func (r *Reconciler) DefaultVPAController() *autoscalingv1.VerticalPodAutoscaler
 	return vpa
 }
 
+// getDefaultNodeSelector returns the appropriate node selector based on
+// control plane topology.
+func (r *Reconciler) getDefaultNodeSelector() map[string]string {
+	if r.config.IsExternalControlPlane {
+		// For HCP clusters, schedule on any Linux node (worker nodes)
+		return map[string]string{
+			"kubernetes.io/os": "linux",
+		}
+	}
+	// For standard clusters, schedule on master nodes
+	return map[string]string{
+		"node-role.kubernetes.io/master": "",
+		"kubernetes.io/os":               "linux",
+	}
+}
+
+// getDefaultTolerations returns the appropriate tolerations based on
+// control plane topology.
+func (r *Reconciler) getDefaultTolerations() []corev1.Toleration {
+	tolerations := []corev1.Toleration{
+		{
+			Key:      "CriticalAddonsOnly",
+			Operator: corev1.TolerationOpExists,
+		},
+	}
+
+	if !r.config.IsExternalControlPlane {
+		// For standard clusters, add master node toleration
+		tolerations = append(tolerations, corev1.Toleration{
+			Key:      "node-role.kubernetes.io/master",
+			Effect:   corev1.TaintEffectNoSchedule,
+			Operator: corev1.TolerationOpExists,
+		})
+	}
+
+	return tolerations
+}
+
 // VPAPodSpec returns the expected podSpec for the deployment belonging
 // to the given VerticalPodAutoscalerController.
 func (r *Reconciler) VPAPodSpec(vpa *autoscalingv1.VerticalPodAutoscalerController, params ControllerParams) *corev1.PodSpec {
@@ -691,14 +733,15 @@ func (r *Reconciler) VPAPodSpec(vpa *autoscalingv1.VerticalPodAutoscalerControll
 	}
 	gracePeriod := int64(30)
 
+	// Determine nodeSelector and tolerations based on control plane topology
+	nodeSelector := r.getDefaultNodeSelector()
+	tolerations := r.getDefaultTolerations()
+
 	spec := &corev1.PodSpec{
 		ServiceAccountName:       params.ServiceAccount,
 		DeprecatedServiceAccount: params.ServiceAccount,
 		PriorityClassName:        params.PriorityClassName,
-		NodeSelector: map[string]string{
-			"node-role.kubernetes.io/master": "",
-			"beta.kubernetes.io/os":          "linux",
-		},
+		NodeSelector:             nodeSelector,
 		Containers: []corev1.Container{
 			{
 				Name:            "vertical-pod-autoscaler",
@@ -742,18 +785,7 @@ func (r *Reconciler) VPAPodSpec(vpa *autoscalingv1.VerticalPodAutoscalerControll
 		TerminationGracePeriodSeconds: &gracePeriod,
 		SchedulerName:                 "default-scheduler",
 		SecurityContext:               &corev1.PodSecurityContext{},
-		Tolerations: []corev1.Toleration{
-			{
-				Key:      "CriticalAddonsOnly",
-				Operator: corev1.TolerationOpExists,
-			},
-			{
-
-				Key:      "node-role.kubernetes.io/master",
-				Effect:   corev1.TaintEffectNoSchedule,
-				Operator: corev1.TolerationOpExists,
-			},
-		},
+		Tolerations:                   tolerations,
 	}
 
 	return spec

--- a/pkg/controller/verticalpodautoscaler/verticalpodautoscaler_test.go
+++ b/pkg/controller/verticalpodautoscaler/verticalpodautoscaler_test.go
@@ -373,6 +373,142 @@ func TestObjectReference(t *testing.T) {
 	}
 }
 
+func TestVPAPodSpecNodeSelector(t *testing.T) {
+	testCases := []struct {
+		name                   string
+		isExternalControlPlane bool
+		expectedNodeSelector   map[string]string
+	}{
+		{
+			name:                   "standard cluster - master node selector",
+			isExternalControlPlane: false,
+			expectedNodeSelector: map[string]string{
+				"node-role.kubernetes.io/master": "",
+				"kubernetes.io/os":               "linux",
+			},
+		},
+		{
+			name:                   "HCP cluster - worker node selector",
+			isExternalControlPlane: true,
+			expectedNodeSelector: map[string]string{
+				"kubernetes.io/os": "linux",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			vpa := NewVerticalPodAutoscaler()
+			config := &Config{
+				Name:                   "test",
+				Namespace:              TestNamespace,
+				ReleaseVersion:         TestReleaseVersion,
+				Image:                  "test/test:v100",
+				IsExternalControlPlane: tc.isExternalControlPlane,
+			}
+			r := &Reconciler{
+				client:   fakeclient.NewFakeClient(vpa),
+				scheme:   scheme.Scheme,
+				recorder: record.NewFakeRecorder(128),
+				config:   config,
+			}
+
+			spec := r.VPAPodSpec(vpa, controllerParams[0]) // Use recommender params
+			assert.Equal(t, tc.expectedNodeSelector, spec.NodeSelector)
+		})
+	}
+}
+
+func TestVPAPodSpecTolerations(t *testing.T) {
+	testCases := []struct {
+		name                   string
+		isExternalControlPlane bool
+		expectMasterToleration bool
+	}{
+		{
+			name:                   "standard cluster - has master toleration",
+			isExternalControlPlane: false,
+			expectMasterToleration: true,
+		},
+		{
+			name:                   "HCP cluster - no master toleration",
+			isExternalControlPlane: true,
+			expectMasterToleration: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			vpa := NewVerticalPodAutoscaler()
+			config := &Config{
+				Name:                   "test",
+				Namespace:              TestNamespace,
+				ReleaseVersion:         TestReleaseVersion,
+				Image:                  "test/test:v100",
+				IsExternalControlPlane: tc.isExternalControlPlane,
+			}
+			r := &Reconciler{
+				client:   fakeclient.NewFakeClient(vpa),
+				scheme:   scheme.Scheme,
+				recorder: record.NewFakeRecorder(128),
+				config:   config,
+			}
+
+			spec := r.VPAPodSpec(vpa, controllerParams[0])
+
+			hasMasterToleration := false
+			for _, tol := range spec.Tolerations {
+				if tol.Key == "node-role.kubernetes.io/master" {
+					hasMasterToleration = true
+					break
+				}
+			}
+			assert.Equal(t, tc.expectMasterToleration, hasMasterToleration)
+
+			// Always should have CriticalAddonsOnly toleration
+			hasCriticalToleration := false
+			for _, tol := range spec.Tolerations {
+				if tol.Key == "CriticalAddonsOnly" {
+					hasCriticalToleration = true
+					break
+				}
+			}
+			assert.True(t, hasCriticalToleration, "should have CriticalAddonsOnly toleration")
+		})
+	}
+}
+
+func TestOverridesStillWorkWithExternalTopology(t *testing.T) {
+	vpa := NewVerticalPodAutoscaler()
+	customSelector := map[string]string{"custom-node": "true"}
+	customTolerations := []corev1.Toleration{
+		{Key: "custom-key", Operator: corev1.TolerationOpExists},
+	}
+
+	vpa.Spec.DeploymentOverrides.Recommender.NodeSelector = customSelector
+	vpa.Spec.DeploymentOverrides.Recommender.Tolerations = customTolerations
+
+	config := &Config{
+		Name:                   "test",
+		Namespace:              TestNamespace,
+		ReleaseVersion:         TestReleaseVersion,
+		Image:                  "test/test:v100",
+		IsExternalControlPlane: true, // Even with HCP topology
+	}
+	r := &Reconciler{
+		client:   fakeclient.NewFakeClient(vpa),
+		scheme:   scheme.Scheme,
+		recorder: record.NewFakeRecorder(128),
+		config:   config,
+	}
+
+	spec := r.RecommenderControllerPodSpec(vpa, controllerParams[0])
+
+	// Manual overrides should take precedence
+	assert.Equal(t, customSelector, spec.NodeSelector)
+	assert.Equal(t, customTolerations, spec.Tolerations)
+}
+
 func TestUpdateAnnotations(t *testing.T) {
 	deployment := helpers.NewTestDeployment(&appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/operator/infrastructure.go
+++ b/pkg/operator/infrastructure.go
@@ -1,0 +1,51 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	osconfig "github.com/openshift/client-go/config/clientset/versioned"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog"
+)
+
+const (
+	// InfrastructureName is the name of the singleton Infrastructure resource
+	InfrastructureName = "cluster"
+)
+
+// GetControlPlaneTopology fetches the Infrastructure resource and returns
+// the control plane topology. Returns ExternalTopologyMode for HCP clusters.
+func GetControlPlaneTopology(config *rest.Config) (configv1.TopologyMode, error) {
+	configClient, err := osconfig.NewForConfig(config)
+	if err != nil {
+		return "", fmt.Errorf("failed to create config client: %w", err)
+	}
+
+	infra, err := configClient.ConfigV1().Infrastructures().Get(
+		context.TODO(),
+		InfrastructureName,
+		metav1.GetOptions{},
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to get Infrastructure resource: %w", err)
+	}
+
+	topology := infra.Status.ControlPlaneTopology
+	klog.Infof("Detected control plane topology: %s", topology)
+	return topology, nil
+}
+
+// IsExternalControlPlane returns true if the cluster has an external
+// control plane (HCP/Hosted Control Plane topology).
+func IsExternalControlPlane(config *rest.Config) bool {
+	topology, err := GetControlPlaneTopology(config)
+	if err != nil {
+		// Log warning but default to standard topology for safety
+		klog.Warningf("Failed to detect control plane topology, assuming standard: %v", err)
+		return false
+	}
+	return topology == configv1.ExternalTopologyMode
+}

--- a/pkg/operator/infrastructure_test.go
+++ b/pkg/operator/infrastructure_test.go
@@ -1,0 +1,78 @@
+package operator
+
+import (
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	fakeconfigclient "github.com/openshift/client-go/config/clientset/versioned/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+)
+
+// TestGetControlPlaneTopology tests the topology detection logic
+// Note: This is a basic test structure. Full integration testing would require
+// a real or more sophisticated mock of the config client.
+func TestGetControlPlaneTopology(t *testing.T) {
+	testCases := []struct {
+		name           string
+		topology       configv1.TopologyMode
+		expectedResult bool
+	}{
+		{
+			name:           "HighlyAvailable topology should return false",
+			topology:       configv1.HighlyAvailableTopologyMode,
+			expectedResult: false,
+		},
+		{
+			name:           "SingleReplica topology should return false",
+			topology:       configv1.SingleReplicaTopologyMode,
+			expectedResult: false,
+		},
+		{
+			name:           "External topology (HCP) should return true",
+			topology:       configv1.ExternalTopologyMode,
+			expectedResult: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a fake Infrastructure resource
+			infra := &configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: InfrastructureName,
+				},
+				Status: configv1.InfrastructureStatus{
+					ControlPlaneTopology: tc.topology,
+				},
+			}
+
+			_ = fakeconfigclient.NewSimpleClientset(infra)
+
+			// Note: The current implementation of IsExternalControlPlane takes a
+			// rest.Config and creates its own client, making it difficult to test
+			// with a fake client. A refactoring to accept a client interface would
+			// make this more testable. For now, we verify the basic logic.
+
+			// Verify the topology matches expected behavior
+			isExternal := tc.topology == configv1.ExternalTopologyMode
+			if isExternal != tc.expectedResult {
+				t.Errorf("topology %s: got %v, want %v", tc.topology, isExternal, tc.expectedResult)
+			}
+		})
+	}
+}
+
+// TestIsExternalControlPlaneFailure tests the error handling
+func TestIsExternalControlPlaneFailure(t *testing.T) {
+	// Create an invalid config that will fail
+	invalidConfig := &rest.Config{
+		Host: "https://invalid-host-that-does-not-exist.example.com:6443",
+	}
+
+	// Should return false when detection fails (safe default)
+	result := IsExternalControlPlane(invalidConfig)
+	if result != false {
+		t.Errorf("Expected false when infrastructure detection fails, got %v", result)
+	}
+}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/openshift/vertical-pod-autoscaler-operator/pkg/apis"
 	"github.com/openshift/vertical-pod-autoscaler-operator/pkg/controller/verticalpodautoscaler"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -18,8 +20,9 @@ const OperatorName = "vertical-pod-autoscaler"
 
 // Operator represents an instance of the vertical-pod-autoscaler-operator.
 type Operator struct {
-	config  *Config
-	manager manager.Manager
+	config       *Config
+	manager      manager.Manager
+	clientConfig *rest.Config
 }
 
 // New returns a new Operator instance with the given config and a
@@ -42,6 +45,7 @@ func New(cfg *Config) (*Operator, error) {
 		},
 	}
 
+	operator.clientConfig = clientConfig
 	operator.manager, err = manager.New(clientConfig, managerOptions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create manager: %v", err)
@@ -99,14 +103,23 @@ func (o *Operator) RelatedObjects() []configv1.ObjectReference {
 // AddControllers configures the various controllers and adds them to
 // the operator's manager instance.
 func (o *Operator) AddControllers() error {
+	// Detect control plane topology
+	isExternalControlPlane := IsExternalControlPlane(o.clientConfig)
+	if isExternalControlPlane {
+		klog.Info("Detected external control plane topology (HCP), VPA components will schedule on worker nodes")
+	} else {
+		klog.Info("Detected standard control plane topology, VPA components will schedule on master nodes")
+	}
+
 	// Setup VerticalPodAutoscalerController.
 	vpa := verticalpodautoscaler.NewReconciler(o.manager, &verticalpodautoscaler.Config{
-		ReleaseVersion: o.config.ReleaseVersion,
-		Name:           o.config.VerticalPodAutoscalerName,
-		Image:          o.config.VerticalPodAutoscalerImage,
-		Namespace:      o.config.VerticalPodAutoscalerNamespace,
-		Verbosity:      o.config.VerticalPodAutoscalerVerbosity,
-		ExtraArgs:      o.config.VerticalPodAutoscalerExtraArgs,
+		ReleaseVersion:         o.config.ReleaseVersion,
+		Name:                   o.config.VerticalPodAutoscalerName,
+		Image:                  o.config.VerticalPodAutoscalerImage,
+		Namespace:              o.config.VerticalPodAutoscalerNamespace,
+		Verbosity:              o.config.VerticalPodAutoscalerVerbosity,
+		ExtraArgs:              o.config.VerticalPodAutoscalerExtraArgs,
+		IsExternalControlPlane: isExternalControlPlane,
 	})
 
 	if err := vpa.AddToManager(o.manager); err != nil {


### PR DESCRIPTION
This is a manual cherry-pick of #244.

Note: there were huge changes to the VPA operator between 4.17 and 4.18, so this cherry-pick required significant manual patch application changes.