### PR TITLE
AUTOSCALE-907: Use operator ns if WATCH_NAMESPACE isn't provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ The operator manages the following custom resource:
   controls the configuration of the cluster's VPA 3 controller instances.
   The operator will only respond to the VerticalPodAutoscalerController resource named "default" in the
   managed namespace, i.e. the value of the `WATCH_NAMESPACE` environment
-  variable.  ([Example][VerticalPodAutoscalerController])
+  variable.  ([Example][VerticalPodAutoscalerController]). If the `WATCH_NAMESPACE` environment is not
+  provided, the namespace where the VPA operator is running will be used.
 
   Many of fields in the spec for VerticalPodAutoscalerController resources correspond to
   command-line arguments of the three VPA controllers and also control which controllers

--- a/internal/operator/config.go
+++ b/internal/operator/config.go
@@ -8,10 +8,6 @@ import (
 )
 
 const (
-	// DefaultWatchNamespace is the default namespace the operator
-	// will watch for instances of its custom resources.
-	DefaultWatchNamespace = "openshift-vertical-pod-autoscaler"
-
 	// DefaultVerticalPodAutoscalerNamespace is the default namespace for
 	// vertical-pod-autoscaler deployments.
 	DefaultVerticalPodAutoscalerNamespace = "openshift-vertical-pod-autoscaler"
@@ -68,7 +64,7 @@ type Config struct {
 // NewConfig returns a new Config object with defaults set.
 func NewConfig() *Config {
 	return &Config{
-		WatchNamespace:                 DefaultWatchNamespace,
+		WatchNamespace:                 DefaultVerticalPodAutoscalerNamespace,
 		VerticalPodAutoscalerNamespace: DefaultVerticalPodAutoscalerNamespace,
 		VerticalPodAutoscalerName:      DefaultVerticalPodAutoscalerName,
 		VerticalPodAutoscalerImage:     DefaultVerticalPodAutoscalerImage,
@@ -85,10 +81,6 @@ func ConfigFromEnvironment() *Config {
 		config.ReleaseVersion = releaseVersion
 	}
 
-	if watchNamespace, ok := os.LookupEnv("WATCH_NAMESPACE"); ok {
-		config.WatchNamespace = watchNamespace
-	}
-
 	if caName, ok := os.LookupEnv("VERTICAL_POD_AUTOSCALER_NAME"); ok {
 		config.VerticalPodAutoscalerName = caName
 	}
@@ -99,6 +91,12 @@ func ConfigFromEnvironment() *Config {
 
 	if caNamespace, ok := os.LookupEnv("VERTICAL_POD_AUTOSCALER_NAMESPACE"); ok {
 		config.VerticalPodAutoscalerNamespace = caNamespace
+	}
+
+	if watchNamespace, ok := os.LookupEnv("WATCH_NAMESPACE"); ok && len(watchNamespace) > 0 {
+		config.WatchNamespace = watchNamespace
+	} else {
+		config.WatchNamespace = config.VerticalPodAutoscalerNamespace
 	}
 
 	if caVerbosity, ok := os.LookupEnv("VERTICAL_POD_AUTOSCALER_VERBOSITY"); ok {


### PR DESCRIPTION
Since there is no watch namespace in OLMv1, we should fall back to the operator's namespace if no watch namespace is provided. But there are still users of the older OLM API whose VPA we still want to avoid breaking, so if the watch namespace is provided, continue to use it.