### PR TITLE
AUTOSCALE-900: Add agentic SDLC artifacts to vertical-pod-autoscaler-operator

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,81 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# Docs: https://docs.coderabbit.ai/getting-started/configure-coderabbit
+
+language: en-US
+early_access: false
+
+reviews:
+  profile: "chill"
+  high_level_summary: false
+  poem: false
+  request_changes_workflow: false
+  collapse_walkthrough: true
+
+  path_filters:
+  - "!vendor/**"
+  - "!**/vendor/**"
+  - "!**/zz_generated*"
+  - "!go.sum"
+  - "!bundle/manifests/**"
+
+  path_instructions:
+  - path: "internal/controller/**/*.go"
+    instructions: |
+      Review for idempotent reconciliation, proper error handling, and
+      status subresource updates. The controller manages three operand
+      deployments plus webhook TLS resources. Verify recommendationOnly
+      mode is respected and that operand spec changes do not fight
+      with user overrides in VerticalPodAutoscalerController.
+
+  - path: "api/**/*.go"
+    instructions: |
+      Review CRD API types for backward compatibility, correct
+      kubebuilder validation markers, proper JSON tags with omitempty
+      on optional fields, and deepcopy compliance. API changes require
+      regenerating CRDs (make manifests) and deepcopy (make generate),
+      and may need OLM CSV descriptor updates.
+
+  - path: "internal/operator/**/*.go"
+    instructions: |
+      Operator configuration and status helpers. Changes here affect
+      startup behavior and cluster version reporting. Environment
+      variable names are part of the product contract on OpenShift.
+
+  - path: "config/vpa/**"
+    instructions: |
+      Operand RBAC and VPA CRD manifests maintained in this repo but
+      sourced from openshift/kubernetes-autoscaler. Run make
+      manifest-diff after edits. OpenShift-specific RBAC deltas belong
+      in hack/filter-upstream-rbac.jq. Also run make bundle after edits.
+
+  - path: "bundle/**"
+    instructions: |
+      Files not in bundle/manifests are needed for the ART build process.
+      Mark that changes here can potentially break the productized build, but don't recommend changes.
+
+  - path: "**/*_test.go"
+    instructions: |
+      Verify tests are table-driven where appropriate, have
+      deterministic names, and include proper cleanup. Controller
+      tests should use envtest patterns already in the suite.
+
+  tools:
+    gitleaks:
+      enabled: true
+    golangci-lint:
+      enabled: true
+    hadolint:
+      enabled: true
+
+knowledge_base:
+  code_guidelines:
+    enabled: true
+    filePatterns:
+    - "**/AGENTS.md"
+    - "**/CONTRIBUTING.md"
+  learnings:
+    scope: auto
+  issues:
+    scope: auto
+  pull_requests:
+    scope: auto

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,110 @@
+# AGENTS.md — openshift/vertical-pod-autoscaler-operator
+
+This file provides AI-specific guidance for working in the Vertical Pod Autoscaler Operator. For contribution guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Project Overview
+
+This repo is the **Vertical Pod Autoscaler (VPA) Operator** for OpenShift. It deploys and configures the three VPA controller binaries from [openshift/kubernetes-autoscaler](https://github.com/openshift/kubernetes-autoscaler):
+
+| Controller | Role |
+|------------|------|
+| Recommender | Monitors resource usage and publishes recommendations |
+| Admission plugin | Sets resource requests on new or restarted pods |
+| Updater | Evicts or in-place updates pods whose requests differ from recommendations |
+
+The operator watches a singleton `VerticalPodAutoscalerController` CR named `default` in the managed namespace (`openshift-vertical-pod-autoscaler` by default). That CR maps to command-line arguments and deployment configuration for the three operand deployments.
+
+End users create `VerticalPodAutoscaler` objects (from the upstream VPA API group `autoscaling.k8s.io`) to opt workloads into autoscaling. The operator does not reconcile those objects directly. It only manages the cluster-level VPA installation.
+
+## Repository Structure
+
+```text
+api/v1/                          # VerticalPodAutoscalerController CRD types
+cmd/main.go                      # Operator entry point
+internal/
+  controller/verticalpodautoscaler/  # Main reconciliation loop
+  operator/                      # Operator config from environment, status, infrastructure
+  lib/resourcemerge/             # Merge helpers for operand objects
+  util/                          # TLS and misc helpers
+  version/                       # Build version injection
+config/
+  crd/bases/                     # Generated VerticalPodAutoscalerController CRD
+  manager/                       # Operator Deployment kustomize overlay
+  manifests/                     # OLM ClusterServiceVersion base
+  vpa/                           # Operand RBAC and VPA CRD (synced with kubernetes-autoscaler)
+  olm-catalog/                   # CatalogSource kustomize overlay
+  samples/                       # Example VerticalPodAutoscalerController
+bundle/                          # Generated OLM bundle (do not hand-edit)
+hack/
+  manifest-diff-upstream.sh      # CI check: operand manifests match kubernetes-autoscaler
+  e2e.sh                         # E2E entrypoint for operator and upstream VPA tests
+test/
+  e2e/                           # Operator-specific e2e tests
+  helpers/                       # Shared test utilities
+```
+
+## Architecture: What Is Not Obvious
+
+### Reconciliation flow
+
+1. The controller reads the `default` `VerticalPodAutoscalerController` in the watch namespace.
+2. It creates or updates three operand Deployments (recommender, admission plugin, updater), a webhook Service, TLS secrets/configmaps.
+3. Operator and operand RBAC is reconciled by OLM, not the operator itself.
+4. `recommendationOnly: true` on the CR suppresses the updater and admission plugin. Only the recommender runs.
+5. Operand container images come from the `VPA_OPERAND_IMAGE` environment variable on the operator Deployment, not from the CR spec.
+6. On OpenShift, the admission webhook Service uses serving-cert annotations. The controller wires TLS via `controller-runtime-common` and `library-go` crypto helpers.
+
+### Operand / operator split
+
+Controller binaries and their RBAC live in [openshift/kubernetes-autoscaler](https://github.com/openshift/kubernetes-autoscaler) under `vertical-pod-autoscaler/`. This operator repo carries deployment manifests in `config/vpa/` and reconciles them at runtime.
+
+`hack/manifest-diff-upstream.sh` compares `config/vpa/` against the branch of `openshift/kubernetes-autoscaler` that the operator is synced with. Update `operand_branch` in that script when the operand sync target moves.
+
+### Singleton CR contract
+
+The operator only reconciles the CR named `default`. Other `VerticalPodAutoscalerController` objects are ignored. The watch namespace is set by `WATCH_NAMESPACE` on the operator pod.
+
+## Common Pitfalls
+
+1. **Do not hand-edit generated files.** `api/v1/zz_generated.deepcopy.go`, `config/crd/bases/`, and everything under `bundle/manifests/` are generated. Run `make generate`, `make manifests`, and `make bundle` instead.
+
+2. **Keep operand manifests in sync with kubernetes-autoscaler.** Changes to `config/vpa/vpa-rbac.yaml` or `config/vpa/vpa-crd.yaml` must match the corresponding files in the operand repo. Run `make manifest-diff` before pushing. OpenShift-specific RBAC deltas belong in `hack/filter-upstream-rbac.jq`.
+
+3. **Do not assume all three controllers always run.** Check `recommendationOnly` handling in `verticalpodautoscaler_controller.go` before adding logic that depends on the updater or admission plugin.
+
+4. **Bundle generation has side effects.** `make bundle` can potentially edit `config/manager/kustomization.yaml` if you specify an override environment variable such as `OPERATOR_IMG=...` for local testing purposes.
+Revert unintended kustomize edits before committing.
+
+5. **E2E tests clone upstream VPA tests.** `hack/e2e.sh` vendors upstream e2e tests from `kubernetes-autoscaler`. The `operator` suite runs `./test/e2e/` in this repo. Other suites run upstream tests with Ginkgo focus filters.
+
+6. **Float fields in the API.** The `VerticalPodAutoscalerController` spec uses `float64` for recommender tuning fields. `make manifests` requires `crd:allowDangerousTypes=true` because of this.
+
+7. **CI skips doc-only PRs.** Jobs use `skip_if_only_changed` for `*.md` files. Markdown-only changes will not exercise unit, lint, or e2e jobs.
+
+## Human-in-the-Loop Triggers
+
+Stop and consult a human before:
+
+- **Modifying CRD API types** (`api/v1/`) — API changes affect OLM CSV descriptors, bundle generation, and cluster upgrades
+- **Changing RBAC** in `config/vpa/` or operator RBAC — privilege changes need security review and operand sync
+- **Changing webhook TLS behavior** — affects admission on every pod create/update in clusters with VPA enabled
+- **Bumping the operand sync branch** in `hack/manifest-diff-upstream.sh`
+- **Changing anything in bundle/** — some files are needed by the ART team, and some are auto-generated
+- **Operand image or deployment topology changes** that should be coordinated with `kubernetes-autoscaler`
+
+## Paired Changes
+
+| If you change... | Also update... |
+|-----------------|----------------|
+| API types in `api/v1/` | Run `make generate && make manifests && make bundle`; update CSV if new spec fields need OLM descriptors |
+| Operand RBAC or VPA CRD in `config/vpa/` | Verify with `make manifest-diff`; coordinate with `openshift/kubernetes-autoscaler` |
+| OpenShift-specific RBAC filtering | `hack/filter-upstream-rbac.jq` |
+| Operator Deployment env vars | `config/manager/manager.yaml`, `Makefile` `predeploy` target, and CI if image substitution changes |
+| E2E suite behavior | `hack/e2e.sh` and CI job definitions in openshift/release |
+
+## Further Reading
+
+- [CONTRIBUTING.md](CONTRIBUTING.md) — PR workflow, test expectations, pre-submit checklist
+- [README.md](README.md) — Deployment and local development
+- Operand source: [openshift/kubernetes-autoscaler/vertical-pod-autoscaler](https://github.com/openshift/kubernetes-autoscaler/tree/main/vertical-pod-autoscaler)
+- CI config: [openshift/release/.../vertical-pod-autoscaler-operator/](https://github.com/openshift/release/tree/main/ci-operator/config/openshift/vertical-pod-autoscaler-operator)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,166 @@
+# Contributing to Vertical Pod Autoscaler Operator
+
+This document covers contribution guidelines for [openshift/vertical-pod-autoscaler-operator](https://github.com/openshift/vertical-pod-autoscaler-operator).
+
+## Related Resources
+
+| Resource | Link |
+|----------|------|
+| Operand repo | [openshift/kubernetes-autoscaler](https://github.com/openshift/kubernetes-autoscaler) (VPA controllers live under `vertical-pod-autoscaler/`) |
+| CI configuration | [openshift/release/.../vertical-pod-autoscaler-operator/](https://github.com/openshift/release/tree/main/ci-operator/config/openshift/vertical-pod-autoscaler-operator) |
+| AI guidance | [AGENTS.md](AGENTS.md) |
+| OpenShift docs | [Vertical Pod Autoscaler](https://docs.openshift.com/container-platform/latest/nodes/pods/nodes-pods-vertical-autoscaler.html) |
+
+## Review and Approval Policy
+
+Every change in every pull request must be understood and approved by two humans. This can be the PR author and a reviewer, or, if the author used an AI tool and does not fully understand the contents of the PR, two human reviewers.
+
+**Exception:** PRs authored by deterministic automation tools that are part of our CI and related systems (whose code has been reviewed by the OpenShift engineering org) can be merged with a single human review.
+
+Every change should be closely scrutinized for bugs. Our software is complex with many interdependencies. Review changes from multiple angles:
+
+- **Product architecture**: Does this fit the intended design of the VPA operator and OpenShift VPA?
+- **Security**: Are there new attack surfaces, credential handling issues, or privilege escalations?
+- **Thread safety**: The operator reconciles multiple deployments and webhook resources concurrently. Are shared resources handled correctly?
+- **Regressions**: Could this break existing VPA controller deployments, webhook TLS, or operand upgrades?
+- **Effects on other components**: How does this impact the operand in `kubernetes-autoscaler`, cluster upgrades, or OLM bundle generation?
+
+## PR Title Convention
+
+PR titles should be prefixed with a Jira ticket reference:
+
+```text
+AUTOSCALE-123: Fix the whatsit in the thingamajig
+OCPBUGS-456: Correct nil pointer in webhook reconciliation
+NO-JIRA: Update Go module dependencies
+```
+
+## PR Workflow
+
+This repo uses [OpenShift CI (Prow)](https://docs.ci.openshift.org/) for continuous integration. PRs are automatically merged once all required tests pass and the correct labels are present.
+
+### Required labels for merge
+
+- `lgtm` — Added by a reviewer via the `/lgtm` command. Any developer from the OpenShift org can add this after reviewing the PR.
+- `approved` — Added by an approver listed in the [OWNERS](OWNERS) file via the `/approve` command.
+- `verified` — Added by anyone in the OpenShift org, but typically by the PR author.
+
+### Useful commands
+
+Comment these on the PR:
+
+| Command | Effect |
+|---------|--------|
+| `/lgtm` | Add the `lgtm` label after reviewing |
+| `/lgtm cancel` | Remove the `lgtm` label |
+| `/approve` | Add the `approved` label (OWNERS approvers only) |
+| `/retest` | Re-run all failed required tests |
+| `/retest-required` | Re-run only the failed required tests |
+| `/test <test-name>` | Run a specific test, e.g. `/test unit` or `/test e2e-aws-olm` |
+| `/hold` | Prevent the PR from being merged |
+| `/hold cancel` | Remove the hold and allow merging |
+| `/verified` | Mark the PR as verified |
+| `/cherry-pick release-4.23` | Create a cherry-pick PR to a release branch |
+| `/pipeline required` | Manually trigger all required second-stage tests (e.g., E2Es) without waiting for `/lgtm` |
+
+### LGTM mode and E2E tests
+
+Repos enrolled in LGTM mode defer second-stage tests (such as E2Es) until the `lgtm` label is applied. This avoids wasting CI resources on PRs that haven't been reviewed yet. If you need to run E2Es before getting `/lgtm` (e.g., to validate before requesting review), use `/pipeline required`.
+
+### Preventing premature merges
+
+- Add the `WIP:` prefix to the PR title (e.g., `WIP: AUTOSCALE-123: Work in progress`). Prow adds the `do-not-merge/work-in-progress` label automatically.
+- Use `/hold` to temporarily block merging while awaiting additional review or testing.
+
+## Test Expectations
+
+PRs should include tests to verify correctness and prevent future regressions:
+
+- **Unit tests**: Required for new logic, bug fixes, and behavior changes. Run with `make test`.
+- **Controller envtests**: The controller package uses envtest. Add or update tests in `internal/controller/verticalpodautoscaler/` when reconciliation behavior changes.
+- **Manifest diff**: `make manifest-diff` compares operand RBAC and CRDs against [openshift/kubernetes-autoscaler](https://github.com/openshift/kubernetes-autoscaler). Run this when changing `config/vpa/`.
+- **E2E tests**: Expected for new features or significant behavior changes. CI runs operator and upstream VPA e2e suites on AWS (`e2e-aws-operator`, `e2e-aws-olm`, `e2e-aws-operator-components`, `e2e-aws-operator-actuation`).
+- **Upgrade tests**: This test should detect any regressions in the operator or operand during an operator upgrade scenario (`e2e-aws-upgrade`).
+
+## Verified Label
+
+Use `/verified` to indicate changes have been verified. Examples:
+
+```text
+/verified
+```
+
+Mark as verified by referencing specific test coverage:
+
+```text
+/verified by unit
+/verified by e2e-aws-olm
+/verified by E2Es
+```
+
+If verification will happen later (e.g., by QE or in a staging environment):
+
+```text
+/verified later QE
+/verified later @maxcao13
+```
+
+## Generated Code
+
+The following files are generated and should never be hand-edited:
+
+| File(s) | Generator | Regenerate with |
+|---------|-----------|-----------------|
+| `api/v1/zz_generated.deepcopy.go` | controller-gen | `make generate` |
+| `config/crd/bases/*.yaml` | controller-gen | `make manifests` |
+| `bundle/` | operator-sdk | `make bundle` |
+| Parts of `config/manifests/` | operator-sdk | `make bundle` |
+
+After modifying API types, regenerate and commit the results in the same PR. CI runs `make ensure-commands-are-noops` to verify generated output is current.
+
+Operand manifests in `config/vpa/` are maintained manually but must stay in sync with upstream. Use `make manifest-diff` to check.
+
+## Development Quick Reference
+
+| Task | Command |
+|------|---------|
+| Build operator binary | `make build` |
+| Run operator locally | `make run` |
+| Run unit tests | `make test` |
+| Run linters | `make lint` |
+| Run go vet | `make vet` |
+| Format code | `make fmt` |
+| Generate deepcopy | `make generate` |
+| Generate CRD/RBAC manifests | `make manifests` |
+| Compare operand manifests to upstream | `make manifest-diff` |
+| Lint YAML manifests | `make yamllint` |
+| Run all local checks | `make check` |
+| Verify generated code is up to date | `make ensure-commands-are-noops` |
+| Deploy to cluster (manifests) | `make deploy OPERATOR_IMG=<image>` |
+| Generate and validate OLM bundle | `make bundle` |
+| Run upstream VPA e2e suite | `make test-e2e SUITE=full-vpa` |
+| Run operator e2e suite | `make test-e2e SUITE=operator` |
+
+## Pre-Submit Checklist
+
+Before requesting review:
+
+1. `make build` — Verify the code compiles
+2. `make test` — Run unit tests
+3. `make lint` — Run linters
+4. `make check` — Run manifest-diff, yamllint, lint, and test
+5. `make ensure-commands-are-noops` — Ensure generated files are up to date (if API or bundle inputs changed)
+6. Review your diff for secrets, credentials, or debug code
+7. Address any [CodeRabbit](https://coderabbit.ai/) review feedback before requesting human review. Responding with an explanation of why you are not acting on a suggestion is fine.
+
+## Code Style
+
+- Run `make fmt` before committing
+- Follow Go conventions for error strings: lowercase, no trailing punctuation, wrap with `fmt.Errorf("context: %w", err)`
+- Use structured logging with logr/klog: constant messages, key-value pairs in lowerCamelCase
+- Import ordering: stdlib, external packages, internal packages (separated by blank lines)
+
+## AI Code Review
+
+Our repos use CodeRabbit for automated AI code review. CodeRabbit will post review comments on your PR automatically.
+As a courtesy to the human reviewer who follows, please address CodeRabbit’s feedback before requesting human review. You do not need to accept every suggestion — responding with an explanation of why you are not taking action on a comment is perfectly acceptable. The goal is to resolve straightforward issues so that human reviewers can focus on the substantive aspects of the change.

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ test-scorecard: operator-sdk ## Run the scorecard tests. Requires an OpenShift c
 	$(OPERATOR_SDK) scorecard bundle -n default -w 300s
 
 .PHONY: check
-check: manifest-diff lint yamllint test ## Run quick checks for a dev before pushing code.
+check: build manifest-diff lint-config lint yamllint test ensure-commands-are-noops ## Run quick checks for a dev before pushing code.
 
 .PHONY: ensure-commands-are-noops ## Ensure that make generate and bundle are no-ops.
 ensure-commands-are-noops: generate bundle

--- a/README.md
+++ b/README.md
@@ -1,5 +1,27 @@
 # Vertical Pod Autoscaler Operator
 
+The Vertical Pod Autoscaler Operator installs and configures the OpenShift
+[Vertical Pod Autoscaler][1] on a cluster. It is deployed by OLM in product
+clusters and manages the three VPA controller deployments from
+[openshift/kubernetes-autoscaler](https://github.com/openshift/kubernetes-autoscaler).
+
+The operator watches a singleton `VerticalPodAutoscalerController` custom
+resource (named `default`) and reconciles operand Deployments and webhook TLS.
+Workloads opt in to VPA by creating `VerticalPodAutoscaler` objects
+using the upstream `autoscaling.k8s.io` API.
+
+## Related Resources
+
+| Resource | Link |
+|----------|------|
+| Operand source | [openshift/kubernetes-autoscaler](https://github.com/openshift/kubernetes-autoscaler) |
+| CI configuration | [openshift/release/.../vertical-pod-autoscaler-operator/](https://github.com/openshift/release/tree/main/ci-operator/config/openshift/vertical-pod-autoscaler-operator) |
+| Product documentation | [OpenShift VPA docs][2] |
+| Contributing | [CONTRIBUTING.md](CONTRIBUTING.md) |
+| AI guidance | [AGENTS.md](AGENTS.md) |
+
+## Controllers
+
 The vertical-pod-autoscaler-operator manages deployments and configurations
 of the OpenShift [Vertical Pod Autoscaler][1]'s three controllers. The three
 controllers are:
@@ -11,8 +33,8 @@ controllers are:
   new pods which are being restarted (after an eviction by the Updater) or by any
   other pod restart.
 * `Updater`, which checks which of the managed pods have incorrect resources set,
-  and evicts any it finds so that the pods can be recreated by their
-  controllers with the updated resource requests.
+  and evicts or in-place updates any it finds so that the pods can be recreated
+  or resized with the updated resource requests.
 
 [1]: https://github.com/openshift/kubernetes-autoscaler/tree/master/vertical-pod-autoscaler
 


### PR DESCRIPTION
See https://redhat.atlassian.net/browse/AUTOSCALE-814 for details about the overall effort.

~Currently coderabbit is not enabled for this repo. That work is tracked in https://redhat.atlassian.net/browse/DPP-21848 (and is blocked on the DPP team).~
It is now enabled, as we can see.

Includes changes to
- .coderabbit.yaml
- AGENTS.md
- CONTRIBUTING.yaml
- README.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added project guidance covering architecture, reconciliation behavior, resource management, testing, and common development pitfalls.
  - Added contributor instructions covering review requirements, pull request workflow, testing, generated files, and coding standards.
  - Expanded the README with an overview of the Vertical Pod Autoscaler Operator, deployment model, managed controllers, custom resources, and workload integration.
- **Chores**
  - Added automated review configuration with path-specific guidance and security and linting checks.
  - Expanded validation checks to include builds, configuration linting, and command verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->